### PR TITLE
✨[CCI-31] 면접자 면접 대기실 입장/퇴장 API

### DIFF
--- a/src/main/java/cloudcomputinginha/demo/apiPayload/code/handler/MemberInterviewHandler.java
+++ b/src/main/java/cloudcomputinginha/demo/apiPayload/code/handler/MemberInterviewHandler.java
@@ -1,0 +1,10 @@
+package cloudcomputinginha.demo.apiPayload.code.handler;
+
+import cloudcomputinginha.demo.apiPayload.code.BaseErrorCode;
+import cloudcomputinginha.demo.apiPayload.exception.GeneralException;
+
+public class MemberInterviewHandler extends GeneralException {
+    public MemberInterviewHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/cloudcomputinginha/demo/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/cloudcomputinginha/demo/apiPayload/code/status/ErrorStatus.java
@@ -11,8 +11,8 @@ import org.springframework.http.HttpStatus;
 public enum ErrorStatus implements BaseErrorCode {
     // 가장 일반적인 응답
     _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
-    _BAD_REQUEST(HttpStatus.BAD_REQUEST,"COMMON400","잘못된 요청입니다."),
-    _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
+    _BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청입니다."),
+    _UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다."),
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
 
 
@@ -21,8 +21,14 @@ public enum ErrorStatus implements BaseErrorCode {
     NICKNAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "MEMBER4002", "닉네임은 필수 입니다."),
 
     // 예시,,,
-    ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "ARTICLE4001", "게시글이 없습니다.");
+    ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "ARTICLE4001", "게시글이 없습니다."),
 
+    // 면접 관련 에러
+    INTERVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "INTERVIEW4001", "해당하는 인터뷰를 찾을 수 없습니다."),
+
+    // 멤버 인터뷰 관련 에러
+    INTERVIEW_STATUS_INVALID(HttpStatus.BAD_REQUEST, "MEMBERINTERVIEW4001", "올바른 인터뷰 상태가 아닙니다."),
+    MEMBER_INTERVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBERINTERVIEW4002", "해당하는 사용자 인터뷰를 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/cloudcomputinginha/demo/converter/MemberInterviewConverter.java
+++ b/src/main/java/cloudcomputinginha/demo/converter/MemberInterviewConverter.java
@@ -1,0 +1,14 @@
+package cloudcomputinginha.demo.converter;
+
+import cloudcomputinginha.demo.domain.MemberInterview;
+import cloudcomputinginha.demo.web.dto.MemberInterviewResponseDTO;
+
+public class MemberInterviewConverter {
+    public static MemberInterviewResponseDTO.MemberInterviewStatusDTO toMemberInterviewStatusDTO(MemberInterview memberInterview) {
+        return MemberInterviewResponseDTO.MemberInterviewStatusDTO.builder()
+                .memberInterviewId(memberInterview.getId())
+                .status(memberInterview.getStatus())
+                .updatedAt(memberInterview.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/cloudcomputinginha/demo/domain/Interview.java
+++ b/src/main/java/cloudcomputinginha/demo/domain/Interview.java
@@ -33,7 +33,6 @@ public class Interview extends BaseEntity {
 
     private Long hostId;
 
-    @Column(nullable = false)
     private Integer maxParticipants;
 
     @Column(nullable = false, length = 50)

--- a/src/main/java/cloudcomputinginha/demo/domain/InterviewOption.java
+++ b/src/main/java/cloudcomputinginha/demo/domain/InterviewOption.java
@@ -1,16 +1,15 @@
 package cloudcomputinginha.demo.domain;
 
 import cloudcomputinginha.demo.domain.common.BaseEntity;
-import cloudcomputinginha.demo.domain.enums.InterviewType;
 import cloudcomputinginha.demo.domain.enums.InterviewFormat;
+import cloudcomputinginha.demo.domain.enums.InterviewType;
 import cloudcomputinginha.demo.domain.enums.VoiceType;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
+
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @Getter
@@ -44,7 +43,6 @@ public class InterviewOption extends BaseEntity {
 
     private LocalDateTime endedAt;
 
-    @Builder.Default
     @OneToOne(mappedBy = "interviewOption", cascade = CascadeType.ALL)
     private Interview interview;
 }

--- a/src/main/java/cloudcomputinginha/demo/domain/MemberInterview.java
+++ b/src/main/java/cloudcomputinginha/demo/domain/MemberInterview.java
@@ -36,4 +36,8 @@ public class MemberInterview extends BaseEntity {
     @Column(length = 10, nullable = false)
     @Builder.Default
     private InterviewStatus status = InterviewStatus.SCHEDULED;
+
+    public void changeStatus(InterviewStatus status) {
+        this.status = status;
+    }
 }

--- a/src/main/java/cloudcomputinginha/demo/domain/enums/InterviewStatus.java
+++ b/src/main/java/cloudcomputinginha/demo/domain/enums/InterviewStatus.java
@@ -1,5 +1,14 @@
 package cloudcomputinginha.demo.domain.enums;
 
 public enum InterviewStatus {
-    NO_SHOW, SCHEDULED, IN_PROGRESS, DONE
+    NO_SHOW, SCHEDULED, IN_PROGRESS, DONE;
+
+    public static boolean isValid(String status) {
+        try {
+            valueOf(status.toUpperCase());
+            return true;
+        } catch (IllegalArgumentException | NullPointerException e) {
+            return false;
+        }
+    }
 }

--- a/src/main/java/cloudcomputinginha/demo/repository/InterviewRepository.java
+++ b/src/main/java/cloudcomputinginha/demo/repository/InterviewRepository.java
@@ -1,0 +1,7 @@
+package cloudcomputinginha.demo.repository;
+
+import cloudcomputinginha.demo.domain.Interview;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InterviewRepository extends JpaRepository<Interview, Long> {
+}

--- a/src/main/java/cloudcomputinginha/demo/repository/MemberInterviewRepository.java
+++ b/src/main/java/cloudcomputinginha/demo/repository/MemberInterviewRepository.java
@@ -1,0 +1,14 @@
+package cloudcomputinginha.demo.repository;
+
+import cloudcomputinginha.demo.domain.Interview;
+import cloudcomputinginha.demo.domain.MemberInterview;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface MemberInterviewRepository extends JpaRepository<MemberInterview, Long> {
+    List<MemberInterview> interview(Interview interview);
+
+    Optional<MemberInterview> findByMemberIdAndInterviewId(Long memberId, Long interviewId);
+}

--- a/src/main/java/cloudcomputinginha/demo/repository/MemberRepository.java
+++ b/src/main/java/cloudcomputinginha/demo/repository/MemberRepository.java
@@ -1,0 +1,7 @@
+package cloudcomputinginha.demo.repository;
+
+import cloudcomputinginha.demo.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/cloudcomputinginha/demo/service/MemberInterviewCommandService.java
+++ b/src/main/java/cloudcomputinginha/demo/service/MemberInterviewCommandService.java
@@ -1,0 +1,8 @@
+package cloudcomputinginha.demo.service;
+
+import cloudcomputinginha.demo.domain.MemberInterview;
+import cloudcomputinginha.demo.web.dto.MemberInterviewRequestDTO;
+
+public interface MemberInterviewCommandService {
+    public MemberInterview changeMemberInterviewStatus(Long interviewId, MemberInterviewRequestDTO.changeMemberStatusDTO memberInterviewRequestDTO);
+}

--- a/src/main/java/cloudcomputinginha/demo/service/MemberInterviewCommandServiceImpl.java
+++ b/src/main/java/cloudcomputinginha/demo/service/MemberInterviewCommandServiceImpl.java
@@ -1,0 +1,27 @@
+package cloudcomputinginha.demo.service;
+
+import cloudcomputinginha.demo.apiPayload.code.handler.MemberInterviewHandler;
+import cloudcomputinginha.demo.apiPayload.code.status.ErrorStatus;
+import cloudcomputinginha.demo.domain.MemberInterview;
+import cloudcomputinginha.demo.repository.MemberInterviewRepository;
+import cloudcomputinginha.demo.web.dto.MemberInterviewRequestDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MemberInterviewCommandServiceImpl implements MemberInterviewCommandService {
+    private final MemberInterviewRepository memberInterviewRepository;
+
+    @Override
+    public MemberInterview changeMemberInterviewStatus(Long interviewId, MemberInterviewRequestDTO.changeMemberStatusDTO memberInterviewRequestDTO) {
+        MemberInterview memberInterview = memberInterviewRepository.findByMemberIdAndInterviewId(memberInterviewRequestDTO.getMemberId(), interviewId)
+                .orElseThrow(() -> new MemberInterviewHandler(ErrorStatus.MEMBER_INTERVIEW_NOT_FOUND));
+
+        memberInterview.changeStatus(memberInterviewRequestDTO.getStatus());
+        memberInterviewRepository.save(memberInterview);
+        return memberInterview;
+    }
+}

--- a/src/main/java/cloudcomputinginha/demo/validation/annotation/ExistInterview.java
+++ b/src/main/java/cloudcomputinginha/demo/validation/annotation/ExistInterview.java
@@ -1,0 +1,19 @@
+package cloudcomputinginha.demo.validation.annotation;
+
+import cloudcomputinginha.demo.validation.validator.InterviewExistValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = InterviewExistValidator.class)
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ExistInterview {
+    String message() default "해당하는 인터뷰는 존재하지 않습니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/cloudcomputinginha/demo/validation/annotation/ExistMember.java
+++ b/src/main/java/cloudcomputinginha/demo/validation/annotation/ExistMember.java
@@ -1,0 +1,20 @@
+package cloudcomputinginha.demo.validation.annotation;
+
+
+import cloudcomputinginha.demo.validation.validator.MemberExistValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = MemberExistValidator.class)
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ExistMember {
+    String message() default "해당하는 사용자는 존재하지 않습니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/cloudcomputinginha/demo/validation/annotation/ExistMemberInterview.java
+++ b/src/main/java/cloudcomputinginha/demo/validation/annotation/ExistMemberInterview.java
@@ -1,0 +1,20 @@
+package cloudcomputinginha.demo.validation.annotation;
+
+
+import cloudcomputinginha.demo.validation.validator.InterviewExistValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = InterviewExistValidator.class)
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ExistMemberInterview {
+    String message() default "해당하는 사용자 인터뷰는 존재하지 않습니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/cloudcomputinginha/demo/validation/annotation/ValidInterviewStatus.java
+++ b/src/main/java/cloudcomputinginha/demo/validation/annotation/ValidInterviewStatus.java
@@ -1,0 +1,19 @@
+package cloudcomputinginha.demo.validation.annotation;
+
+import cloudcomputinginha.demo.validation.validator.InterviewStatusValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = InterviewStatusValidator.class)
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidInterviewStatus {
+    String message() default "유효하지 않은 사용자의 인터뷰 상태입니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/cloudcomputinginha/demo/validation/validator/InterviewExistValidator.java
+++ b/src/main/java/cloudcomputinginha/demo/validation/validator/InterviewExistValidator.java
@@ -1,0 +1,32 @@
+package cloudcomputinginha.demo.validation.validator;
+
+import cloudcomputinginha.demo.apiPayload.code.status.ErrorStatus;
+import cloudcomputinginha.demo.repository.InterviewRepository;
+import cloudcomputinginha.demo.validation.annotation.ExistInterview;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class InterviewExistValidator implements ConstraintValidator<ExistInterview, Long> {
+    private final InterviewRepository interviewRepository;
+
+    @Override
+    public void initialize(ExistInterview constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(Long value, ConstraintValidatorContext context) {
+        boolean isValid = interviewRepository.existsById(value);
+
+        if (!isValid) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(ErrorStatus.INTERVIEW_NOT_FOUND.toString()).addConstraintViolation();
+        }
+
+        return isValid;
+    }
+}

--- a/src/main/java/cloudcomputinginha/demo/validation/validator/InterviewStatusValidator.java
+++ b/src/main/java/cloudcomputinginha/demo/validation/validator/InterviewStatusValidator.java
@@ -1,0 +1,28 @@
+package cloudcomputinginha.demo.validation.validator;
+
+import cloudcomputinginha.demo.apiPayload.code.status.ErrorStatus;
+import cloudcomputinginha.demo.domain.enums.InterviewStatus;
+import cloudcomputinginha.demo.validation.annotation.ValidInterviewStatus;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import org.springframework.stereotype.Component;
+
+@Component
+public class InterviewStatusValidator implements ConstraintValidator<ValidInterviewStatus, String> {
+    @Override
+    public void initialize(ValidInterviewStatus constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        boolean isValid = InterviewStatus.isValid(value);
+
+        if (!isValid) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(ErrorStatus.INTERVIEW_STATUS_INVALID.toString()).addConstraintViolation();
+        }
+
+        return isValid;
+    }
+}

--- a/src/main/java/cloudcomputinginha/demo/validation/validator/MemberExistValidator.java
+++ b/src/main/java/cloudcomputinginha/demo/validation/validator/MemberExistValidator.java
@@ -1,0 +1,33 @@
+package cloudcomputinginha.demo.validation.validator;
+
+
+import cloudcomputinginha.demo.apiPayload.code.status.ErrorStatus;
+import cloudcomputinginha.demo.repository.MemberRepository;
+import cloudcomputinginha.demo.validation.annotation.ExistMember;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MemberExistValidator implements ConstraintValidator<ExistMember, Long> {
+    private final MemberRepository memberRepository;
+
+    @Override
+    public void initialize(ExistMember constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(Long value, ConstraintValidatorContext context) {
+        boolean isValid = memberRepository.existsById(value);
+
+        if (!isValid) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(ErrorStatus.MEMBER_NOT_FOUND.toString()).addConstraintViolation();
+        }
+
+        return isValid;
+    }
+}

--- a/src/main/java/cloudcomputinginha/demo/validation/validator/MemberInterviewExistValidator.java
+++ b/src/main/java/cloudcomputinginha/demo/validation/validator/MemberInterviewExistValidator.java
@@ -1,0 +1,32 @@
+package cloudcomputinginha.demo.validation.validator;
+
+import cloudcomputinginha.demo.apiPayload.code.status.ErrorStatus;
+import cloudcomputinginha.demo.repository.MemberInterviewRepository;
+import cloudcomputinginha.demo.validation.annotation.ExistMemberInterview;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MemberInterviewExistValidator implements ConstraintValidator<ExistMemberInterview, Long> {
+    private final MemberInterviewRepository memberInterviewRepository;
+
+    @Override
+    public void initialize(ExistMemberInterview constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(Long value, ConstraintValidatorContext context) {
+        boolean isValid = memberInterviewRepository.existsById(value);
+
+        if (!isValid) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(ErrorStatus.MEMBER_INTERVIEW_NOT_FOUND.toString()).addConstraintViolation();
+        }
+
+        return isValid;
+    }
+}

--- a/src/main/java/cloudcomputinginha/demo/web/controller/MemberInterviewRestController.java
+++ b/src/main/java/cloudcomputinginha/demo/web/controller/MemberInterviewRestController.java
@@ -1,0 +1,31 @@
+package cloudcomputinginha.demo.web.controller;
+
+import cloudcomputinginha.demo.apiPayload.ApiResponse;
+import cloudcomputinginha.demo.converter.MemberInterviewConverter;
+import cloudcomputinginha.demo.domain.MemberInterview;
+import cloudcomputinginha.demo.service.MemberInterviewCommandService;
+import cloudcomputinginha.demo.validation.annotation.ExistInterview;
+import cloudcomputinginha.demo.web.dto.MemberInterviewRequestDTO;
+import cloudcomputinginha.demo.web.dto.MemberInterviewResponseDTO;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@Validated
+@RestController
+@Tag(name = "사용자 인터뷰 API")
+@RequiredArgsConstructor
+public class MemberInterviewRestController {
+    private final MemberInterviewCommandService memberInterviewCommandService;
+
+    @PatchMapping("/interviews/{interviewId}/waiting-room")
+    public ApiResponse<MemberInterviewResponseDTO.MemberInterviewStatusDTO> changeParticipantsStatus(@PathVariable @ExistInterview Long interviewId, @RequestBody @Valid MemberInterviewRequestDTO.changeMemberStatusDTO changeMemberStatusDTO) {
+        MemberInterview memberInterview = memberInterviewCommandService.changeMemberInterviewStatus(interviewId, changeMemberStatusDTO);
+        return ApiResponse.onSuccess(MemberInterviewConverter.toMemberInterviewStatusDTO(memberInterview));
+    }
+}

--- a/src/main/java/cloudcomputinginha/demo/web/dto/MemberInterviewRequestDTO.java
+++ b/src/main/java/cloudcomputinginha/demo/web/dto/MemberInterviewRequestDTO.java
@@ -1,0 +1,20 @@
+package cloudcomputinginha.demo.web.dto;
+
+import cloudcomputinginha.demo.domain.enums.InterviewStatus;
+import cloudcomputinginha.demo.validation.annotation.ExistMember;
+import cloudcomputinginha.demo.validation.annotation.ValidInterviewStatus;
+import lombok.Getter;
+
+public class MemberInterviewRequestDTO {
+    @Getter
+    public static class changeMemberStatusDTO {
+        @ExistMember
+        private Long memberId;
+        @ValidInterviewStatus
+        private String status;
+
+        public InterviewStatus getStatus() {
+            return InterviewStatus.valueOf(status.toUpperCase());
+        }
+    }
+}

--- a/src/main/java/cloudcomputinginha/demo/web/dto/MemberInterviewResponseDTO.java
+++ b/src/main/java/cloudcomputinginha/demo/web/dto/MemberInterviewResponseDTO.java
@@ -1,0 +1,18 @@
+package cloudcomputinginha.demo.web.dto;
+
+import cloudcomputinginha.demo.domain.enums.InterviewStatus;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+public class MemberInterviewResponseDTO {
+    @Getter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    public static class MemberInterviewStatusDTO {
+        Long memberInterviewId;
+        InterviewStatus status;
+        LocalDateTime updatedAt;
+    }
+}

--- a/src/main/resources/insert_dummy_data.sql
+++ b/src/main/resources/insert_dummy_data.sql
@@ -36,13 +36,29 @@ VALUES (5, 'Crystal Mclaughlin', '05497963156', 'danny95@williams-hobbs.com', 'D
         'Receive figure any wish inside either among. Behavior radio recently. End crime network modern.',
         'GOOGLE', '14ba6ccc-601b-4a7b-92e1-075a317db784',
         'dd01202ff6b524a0560576401e9c0609c2f3c01669dd2aa3b927a00701964e6f', NOW(), NOW());
+-- 1. InterviewOption 데이터 삽입
+INSERT INTO interview_option (id, interview_format, interview_type, voice_type, question_number,
+                              answer_time, scheduled_at, ended_at, created_at, updated_at)
+VALUES (1, 'ONE_TO_MANY', 'TECHNICAL', 'WOMEN_1', 5, 3, '2025-06-01 10:00:00', '2025-06-01 10:30:00', NOW(), NOW()),
+       (2, 'ONE_TO_ONE', 'BEHAVIORAL', 'MEN_2', 3, 5, '2025-06-02 14:00:00', '2025-06-02 14:30:00', NOW(), NOW()),
+       (3, 'ONE_TO_MANY', 'TECHNICAL', 'MEN_1', 4, 7, '2025-06-03 16:00:00', '2025-06-03 16:40:00', NOW(), NOW());
 
-INSERT INTO interview (interview_id, created_at, updated_at)
-VALUES (1, NOW(), NOW());
-INSERT INTO interview (interview_id, created_at, updated_at)
-VALUES (2, NOW(), NOW());
-INSERT INTO interview (interview_id, created_at, updated_at)
-VALUES (3, NOW(), NOW());
+-- 2. Interview 데이터 삽입
+INSERT INTO interview (interview_id, name, description, corporate_name, job_name,
+                       host_id, max_participants, notice_url, is_open,
+                       interview_option_id, created_at, updated_at)
+VALUES (1, '백엔드 인터뷰', '백엔드 개발자를 위한 기술 인터뷰', 'GPT컴퍼니', '백엔드 개발자',
+        4, 4, 'https://gptonline.ai/notice/1', TRUE,
+        1, NOW(), NOW()),
+
+       (2, 'HR 인터뷰', '행동 기반 면접 테스트', '오픈AI코리아', '인사 담당자',
+        1, NULL, 'https://gptonline.ai/notice/2', FALSE,
+        2, NOW(), NOW()),
+
+       (3, '프론트엔드 인터뷰', '기술 역량 검증을 위한 면접', '테크프렌즈', '프론트엔드 개발자',
+        5, 4, 'https://gptonline.ai/notice/3', TRUE,
+        3, NOW(), NOW());
+
 
 INSERT INTO resume (resume_id, member_id, file_name, file_url, file_size, created_at, updated_at)
 VALUES (1, 1, 'resume_1.pdf', '/files/resume_1.pdf', 321, NOW(), NOW());


### PR DESCRIPTION
## ✨ 작업 개요
✨[CCI-31] 면접자 면접 대기실 입장/퇴장 API

## ✅ 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
- 면접자 면접 대기실 입장/퇴장 API를 개발했습니다.
- "면접 참석자"의 자소서, 이력서를 바탕으로 질문을 해야 하니까 면접을 신청했더라도 입장했는지, 아닌지에 대한 상태 정보를 저장하고자 했습니다.

## 📌 참고 사항(선택)
- 요청과 정상 응답, 에러 응답에 대한 것은 API 명세서 확인해주세요.
- https://www.notion.so/202cbf0e25ee808c8a45fc46b9669f0a?source=copy_link 

- 일단 memberId를 responseBody로 보냈습니다. 로그인 기능 구현 이후 모든 API가 인증 토큰 기반으로 수정될 예정입니다.


## 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

## 🔗 관련 이슈


<!--
## ✨ 작업 개요
회원가입 시 이메일 인증 기능 추가

## ✅ 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요.

- 회원가입 시 이메일 인증 요청 API 추가
- 인증 이메일 발송 기능 구현 (SMTP 기반)
- 이메일 인증 완료 시 계정 활성화 처리 로직 추가
- 관련 테스트 코드 작성 및 Postman 컬렉션 업데이트

📌 참고 사항(선택)
- Gmail SMTP를 사용하는 경우 보안 설정을 낮춰야 테스트가 가능합니다. 관련 문서는 위키에 정리해두었습니다.
- 이메일 템플릿은 기본 HTML로 구성했으며 추후 디자인 적용 예정입니다.

💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

- 이메일 인증 로직이 보안상 문제가 없는지 확인 부탁드립니다.
- 테스트 케이스가 충분한지도 검토 부탁드립니다.

🔗 관련 이슈
#42 회원가입 이메일 인증 기능
-->


[CCI-31]: https://cloudcomputinginha.atlassian.net/browse/CCI-31?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ