### PR TITLE
✨[CCI-27] 일대다 면접 참여 신청 API

### DIFF
--- a/src/main/java/cloudcomputinginha/demo/apiPayload/code/handler/DocumentHandler.java
+++ b/src/main/java/cloudcomputinginha/demo/apiPayload/code/handler/DocumentHandler.java
@@ -1,0 +1,10 @@
+package cloudcomputinginha.demo.apiPayload.code.handler;
+
+import cloudcomputinginha.demo.apiPayload.code.BaseErrorCode;
+import cloudcomputinginha.demo.apiPayload.exception.GeneralException;
+
+public class DocumentHandler extends GeneralException {
+    public DocumentHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/cloudcomputinginha/demo/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/cloudcomputinginha/demo/apiPayload/code/status/ErrorStatus.java
@@ -20,15 +20,26 @@ public enum ErrorStatus implements BaseErrorCode {
     MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER4001", "사용자가 없습니다."),
     NICKNAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "MEMBER4002", "닉네임은 필수 입니다."),
 
-    // 예시,,,
-    ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "ARTICLE4001", "게시글이 없습니다."),
+    // 자소서 관련
+    COVERLETTER_NOT_FOUND(HttpStatus.NOT_FOUND, "COVERLETTER4001", "해당하는 자기소개서를 찾을 수 없습니다."),
+    COVERLETTER_NOT_OWNED(HttpStatus.FORBIDDEN, "COVERLETTER4002", "자기소개서는 해당 회원의 소유가 아닙니다."),
+
+    // 이력서 관련
+    RESUME_NOT_FOUND(HttpStatus.NOT_FOUND, "RESUME4001", "해당하는 이력서를 찾을 수 없습니다."),
+    RESUME_NOT_OWNED(HttpStatus.FORBIDDEN, "RESUME4002", "이력서는 해당 회원의 소유가 아닙니다."),
+
+    // 자소서 + 이력서 관련
+    AT_LEAST_ONE_PRESENT_DOCUMENTS(HttpStatus.BAD_REQUEST, "DOCUMENT4001", "이력서 또는 자기소개서 중 하나는 반드시 입력해야 합니다."),
 
     // 면접 관련 에러
     INTERVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "INTERVIEW4001", "해당하는 인터뷰를 찾을 수 없습니다."),
+    INTERVIEW_NOT_ACCEPTING_MEMBERS(HttpStatus.BAD_REQUEST, "INTERVIEW4002", "현재 인터뷰는 참여자를 받지 않습니다."),
 
-    // 멤버 인터뷰 관련 에러
+    // 멤버 인터뷰 관련 에러,
     INTERVIEW_STATUS_INVALID(HttpStatus.BAD_REQUEST, "MEMBERINTERVIEW4001", "올바른 인터뷰 상태가 아닙니다."),
-    MEMBER_INTERVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBERINTERVIEW4002", "해당하는 사용자 인터뷰를 찾을 수 없습니다.");
+    MEMBER_INTERVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBERINTERVIEW4002", "해당하는 사용자 인터뷰를 찾을 수 없습니다."),
+    MEMBER_INTERVIEW_ALREADY_EXISTS(HttpStatus.CONFLICT, "MEMBERINTERVIEW4003", "이미 해당 인터뷰에 참여 신청이 완료된 회원입니다."),
+    INTERVIEW_CAPACITY_EXCEEDED(HttpStatus.BAD_REQUEST, "MEMBERINTERVIEW4004", "인터뷰 정원이 초과되어 더 이상 신청할 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/cloudcomputinginha/demo/converter/MemberInterviewConverter.java
+++ b/src/main/java/cloudcomputinginha/demo/converter/MemberInterviewConverter.java
@@ -1,6 +1,6 @@
 package cloudcomputinginha.demo.converter;
 
-import cloudcomputinginha.demo.domain.MemberInterview;
+import cloudcomputinginha.demo.domain.*;
 import cloudcomputinginha.demo.web.dto.MemberInterviewResponseDTO;
 
 public class MemberInterviewConverter {
@@ -9,6 +9,22 @@ public class MemberInterviewConverter {
                 .memberInterviewId(memberInterview.getId())
                 .status(memberInterview.getStatus())
                 .updatedAt(memberInterview.getUpdatedAt())
+                .build();
+    }
+
+    public static MemberInterview toMemberInterview(Member member, Interview interview, Resume resume, Coverletter coverletter) {
+        return MemberInterview.builder()
+                .member(member)
+                .interview(interview)
+                .resume(resume)
+                .coverletter(coverletter)
+                .build();
+    }
+
+    public static MemberInterviewResponseDTO.CreateMemberInterviewDTO toMemberInterviewResultDTO(MemberInterview memberInterview) {
+        return MemberInterviewResponseDTO.CreateMemberInterviewDTO.builder()
+                .memberInterviewId(memberInterview.getId())
+                .createdAt(memberInterview.getCreatedAt())
                 .build();
     }
 }

--- a/src/main/java/cloudcomputinginha/demo/domain/Interview.java
+++ b/src/main/java/cloudcomputinginha/demo/domain/Interview.java
@@ -33,12 +33,14 @@ public class Interview extends BaseEntity {
 
     private Long hostId;
 
-    private Integer maxParticipants;
+    @Builder.Default
+    private Integer maxParticipants = 1; //일대일 면접을 기준으로 초기화
 
     @Column(nullable = false, length = 50)
     private String noticeUrl;
 
-    private Boolean isOpen;
+    @Builder.Default
+    private Boolean isOpen = false;
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "interview_option_id", unique = true, nullable = false)

--- a/src/main/java/cloudcomputinginha/demo/repository/CoverletterRepository.java
+++ b/src/main/java/cloudcomputinginha/demo/repository/CoverletterRepository.java
@@ -1,0 +1,7 @@
+package cloudcomputinginha.demo.repository;
+
+import cloudcomputinginha.demo.domain.Coverletter;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CoverletterRepository extends JpaRepository<Coverletter, Long> {
+}

--- a/src/main/java/cloudcomputinginha/demo/repository/MemberInterviewRepository.java
+++ b/src/main/java/cloudcomputinginha/demo/repository/MemberInterviewRepository.java
@@ -11,4 +11,8 @@ public interface MemberInterviewRepository extends JpaRepository<MemberInterview
     List<MemberInterview> interview(Interview interview);
 
     Optional<MemberInterview> findByMemberIdAndInterviewId(Long memberId, Long interviewId);
+
+    boolean existsByMemberIdAndInterviewId(Long memberId, Long interviewId);
+
+    Integer countMemberInterviewByInterviewId(Long id);
 }

--- a/src/main/java/cloudcomputinginha/demo/repository/ResumeRepository.java
+++ b/src/main/java/cloudcomputinginha/demo/repository/ResumeRepository.java
@@ -1,0 +1,7 @@
+package cloudcomputinginha.demo.repository;
+
+import cloudcomputinginha.demo.domain.Resume;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ResumeRepository extends JpaRepository<Resume, Long> {
+}

--- a/src/main/java/cloudcomputinginha/demo/service/MemberInterviewCommandService.java
+++ b/src/main/java/cloudcomputinginha/demo/service/MemberInterviewCommandService.java
@@ -4,5 +4,7 @@ import cloudcomputinginha.demo.domain.MemberInterview;
 import cloudcomputinginha.demo.web.dto.MemberInterviewRequestDTO;
 
 public interface MemberInterviewCommandService {
-    public MemberInterview changeMemberInterviewStatus(Long interviewId, MemberInterviewRequestDTO.changeMemberStatusDTO memberInterviewRequestDTO);
+    MemberInterview changeMemberInterviewStatus(Long interviewId, MemberInterviewRequestDTO.changeMemberStatusDTO memberInterviewRequestDTO);
+
+    MemberInterview createMemberInterview(Long interviewId, MemberInterviewRequestDTO.createMemberInterviewDTO createMemberInterviewDTO);
 }

--- a/src/main/java/cloudcomputinginha/demo/validation/annotation/ExistCoverletter.java
+++ b/src/main/java/cloudcomputinginha/demo/validation/annotation/ExistCoverletter.java
@@ -1,0 +1,20 @@
+package cloudcomputinginha.demo.validation.annotation;
+
+
+import cloudcomputinginha.demo.validation.validator.CoverletterExistValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = CoverletterExistValidator.class)
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ExistCoverletter {
+    String message() default "해당하는 자기소개서는 존재하지 않습니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/cloudcomputinginha/demo/validation/annotation/ExistResume.java
+++ b/src/main/java/cloudcomputinginha/demo/validation/annotation/ExistResume.java
@@ -1,0 +1,20 @@
+package cloudcomputinginha.demo.validation.annotation;
+
+
+import cloudcomputinginha.demo.validation.validator.ResumeExistValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = ResumeExistValidator.class)
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ExistResume {
+    String message() default "해당하는 이력서는 존재하지 않습니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/cloudcomputinginha/demo/validation/validator/CoverletterExistValidator.java
+++ b/src/main/java/cloudcomputinginha/demo/validation/validator/CoverletterExistValidator.java
@@ -1,0 +1,32 @@
+package cloudcomputinginha.demo.validation.validator;
+
+import cloudcomputinginha.demo.apiPayload.code.status.ErrorStatus;
+import cloudcomputinginha.demo.repository.CoverletterRepository;
+import cloudcomputinginha.demo.validation.annotation.ExistCoverletter;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CoverletterExistValidator implements ConstraintValidator<ExistCoverletter, Long> {
+    private final CoverletterRepository coverletterRepository;
+
+    @Override
+    public void initialize(ExistCoverletter constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(Long value, ConstraintValidatorContext context) {
+        boolean isValid = coverletterRepository.existsById(value);
+
+        if (!isValid) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(ErrorStatus.COVERLETTER_NOT_FOUND.toString()).addConstraintViolation();
+        }
+
+        return isValid;
+    }
+}

--- a/src/main/java/cloudcomputinginha/demo/validation/validator/ResumeExistValidator.java
+++ b/src/main/java/cloudcomputinginha/demo/validation/validator/ResumeExistValidator.java
@@ -1,0 +1,33 @@
+package cloudcomputinginha.demo.validation.validator;
+
+
+import cloudcomputinginha.demo.apiPayload.code.status.ErrorStatus;
+import cloudcomputinginha.demo.repository.ResumeRepository;
+import cloudcomputinginha.demo.validation.annotation.ExistResume;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ResumeExistValidator implements ConstraintValidator<ExistResume, Long> {
+    private final ResumeRepository resumeRepository;
+
+    @Override
+    public void initialize(ExistResume constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(Long value, ConstraintValidatorContext context) {
+        boolean isValid = resumeRepository.existsById(value);
+
+        if (!isValid) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(ErrorStatus.RESUME_NOT_FOUND.toString()).addConstraintViolation();
+        }
+
+        return isValid;
+    }
+}

--- a/src/main/java/cloudcomputinginha/demo/web/controller/MemberInterviewRestController.java
+++ b/src/main/java/cloudcomputinginha/demo/web/controller/MemberInterviewRestController.java
@@ -11,10 +11,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Validated
 @RestController
@@ -28,4 +25,11 @@ public class MemberInterviewRestController {
         MemberInterview memberInterview = memberInterviewCommandService.changeMemberInterviewStatus(interviewId, changeMemberStatusDTO);
         return ApiResponse.onSuccess(MemberInterviewConverter.toMemberInterviewStatusDTO(memberInterview));
     }
+
+    @PostMapping("/interviews/{interviewId}")
+    public ApiResponse<MemberInterviewResponseDTO.CreateMemberInterviewDTO> createMemberInterview(@PathVariable @ExistInterview Long interviewId, @RequestBody @Valid MemberInterviewRequestDTO.createMemberInterviewDTO createMemberInterviewDTO) {
+        MemberInterview memberInterview = memberInterviewCommandService.createMemberInterview(interviewId, createMemberInterviewDTO);
+        return ApiResponse.onSuccess(MemberInterviewConverter.toMemberInterviewResultDTO(memberInterview));
+    }
+
 }

--- a/src/main/java/cloudcomputinginha/demo/web/dto/MemberInterviewRequestDTO.java
+++ b/src/main/java/cloudcomputinginha/demo/web/dto/MemberInterviewRequestDTO.java
@@ -1,20 +1,39 @@
 package cloudcomputinginha.demo.web.dto;
 
 import cloudcomputinginha.demo.domain.enums.InterviewStatus;
+import cloudcomputinginha.demo.validation.annotation.ExistCoverletter;
 import cloudcomputinginha.demo.validation.annotation.ExistMember;
+import cloudcomputinginha.demo.validation.annotation.ExistResume;
 import cloudcomputinginha.demo.validation.annotation.ValidInterviewStatus;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
 public class MemberInterviewRequestDTO {
     @Getter
     public static class changeMemberStatusDTO {
         @ExistMember
+        @NotNull
         private Long memberId;
         @ValidInterviewStatus
+        @NotEmpty
         private String status;
 
         public InterviewStatus getStatus() {
             return InterviewStatus.valueOf(status.toUpperCase());
         }
+    }
+
+    @Getter
+    public static class createMemberInterviewDTO {
+        @ExistMember
+        @NotNull
+        private Long memberId;
+        @ExistResume
+        @NotNull
+        private Long resumeId;
+        @ExistCoverletter
+        @NotNull
+        private Long coverletterId;
     }
 }

--- a/src/main/java/cloudcomputinginha/demo/web/dto/MemberInterviewResponseDTO.java
+++ b/src/main/java/cloudcomputinginha/demo/web/dto/MemberInterviewResponseDTO.java
@@ -15,4 +15,13 @@ public class MemberInterviewResponseDTO {
         InterviewStatus status;
         LocalDateTime updatedAt;
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    public static class CreateMemberInterviewDTO {
+        Long memberInterviewId;
+        LocalDateTime createdAt;
+    }
 }


### PR DESCRIPTION
## ✨ 작업 개요
✨[CCI-27] 일대다 면접 참여 신청 API

## ✅ 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
- 기존에 존재하는 면접에 일대다 면접을 신청하는 API입니다.

- 요청은 인터뷰id, 멤버id, 이력서id, 자소서id를 받습니다.
- 응답은 멤버인터뷰id와 생성 일자를 전달합니다.

## 📌 참고 사항(선택)
- 실패 응답이 자세하게 기재되어 있습니다. 확인 바랍니다.
- https://www.notion.so/1fccbf0e25ee80f2a8a0dd8c9c466530?source=copy_link

## 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

## 🔗 관련 이슈
closes #10 

<!--
## ✨ 작업 개요
회원가입 시 이메일 인증 기능 추가

## ✅ 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요.

- 회원가입 시 이메일 인증 요청 API 추가
- 인증 이메일 발송 기능 구현 (SMTP 기반)
- 이메일 인증 완료 시 계정 활성화 처리 로직 추가
- 관련 테스트 코드 작성 및 Postman 컬렉션 업데이트

📌 참고 사항(선택)
- Gmail SMTP를 사용하는 경우 보안 설정을 낮춰야 테스트가 가능합니다. 관련 문서는 위키에 정리해두었습니다.
- 이메일 템플릿은 기본 HTML로 구성했으며 추후 디자인 적용 예정입니다.

💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

- 이메일 인증 로직이 보안상 문제가 없는지 확인 부탁드립니다.
- 테스트 케이스가 충분한지도 검토 부탁드립니다.

🔗 관련 이슈
#42 회원가입 이메일 인증 기능
-->


[CCI-27]: https://cloudcomputinginha.atlassian.net/browse/CCI-27?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability for members to apply to interviews by submitting their resume and cover letter.
  - Introduced new API endpoint for creating member interview applications.
  - Enhanced validation for resume and cover letter existence during application.
  - Improved error messages for interview participation and document validation.

- **Bug Fixes**
  - Strengthened validation on member interview status changes to prevent invalid data.

- **Other Changes**
  - Added new error codes and messages for clearer feedback on interview and document issues.
  - Default values set for interview participant limits and open status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->