### PR TITLE
✨[CCI-30] 면접 종료 API

### DIFF
--- a/src/main/java/cloudcomputinginha/demo/apiPayload/code/handler/InterviewHandler.java
+++ b/src/main/java/cloudcomputinginha/demo/apiPayload/code/handler/InterviewHandler.java
@@ -1,0 +1,10 @@
+package cloudcomputinginha.demo.apiPayload.code.handler;
+
+import cloudcomputinginha.demo.apiPayload.code.BaseErrorCode;
+import cloudcomputinginha.demo.apiPayload.exception.GeneralException;
+
+public class InterviewHandler extends GeneralException {
+    public InterviewHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/cloudcomputinginha/demo/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/cloudcomputinginha/demo/apiPayload/code/status/ErrorStatus.java
@@ -35,6 +35,7 @@ public enum ErrorStatus implements BaseErrorCode {
     INTERVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "INTERVIEW4001", "해당하는 인터뷰를 찾을 수 없습니다."),
     INTERVIEW_NOT_ACCEPTING_MEMBERS(HttpStatus.BAD_REQUEST, "INTERVIEW4002", "현재 인터뷰는 참여자를 받지 않습니다."),
     INTERVIEW_END_TIME_INVALID(HttpStatus.CONFLICT, "INTERVIEW4003", "인터뷰의 종료 시간이 시작 시간보다 빠릅니다."),
+    INTERVIEW_ALREADY_TERMINATED(HttpStatus.CONFLICT, "INTERVIEW4004", "해당하는 인터뷰는 이미 종료되었습니다."),
 
     // 멤버 인터뷰 관련 에러,
     INTERVIEW_STATUS_INVALID(HttpStatus.BAD_REQUEST, "MEMBERINTERVIEW4001", "올바른 인터뷰 상태가 아닙니다."),

--- a/src/main/java/cloudcomputinginha/demo/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/cloudcomputinginha/demo/apiPayload/code/status/ErrorStatus.java
@@ -34,6 +34,7 @@ public enum ErrorStatus implements BaseErrorCode {
     // 면접 관련 에러
     INTERVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "INTERVIEW4001", "해당하는 인터뷰를 찾을 수 없습니다."),
     INTERVIEW_NOT_ACCEPTING_MEMBERS(HttpStatus.BAD_REQUEST, "INTERVIEW4002", "현재 인터뷰는 참여자를 받지 않습니다."),
+    INTERVIEW_END_TIME_INVALID(HttpStatus.CONFLICT, "INTERVIEW4003", "인터뷰의 종료 시간이 시작 시간보다 빠릅니다."),
 
     // 멤버 인터뷰 관련 에러,
     INTERVIEW_STATUS_INVALID(HttpStatus.BAD_REQUEST, "MEMBERINTERVIEW4001", "올바른 인터뷰 상태가 아닙니다."),

--- a/src/main/java/cloudcomputinginha/demo/converter/InterviewConverter.java
+++ b/src/main/java/cloudcomputinginha/demo/converter/InterviewConverter.java
@@ -1,0 +1,13 @@
+package cloudcomputinginha.demo.converter;
+
+import cloudcomputinginha.demo.domain.Interview;
+import cloudcomputinginha.demo.web.dto.InterviewResponseDTO;
+
+public class InterviewConverter {
+    public static InterviewResponseDTO.InterviewEndResultDTO toInterviewEndResultDTO(Interview interview) {
+        return InterviewResponseDTO.InterviewEndResultDTO.builder()
+                .interviewId(interview.getId())
+                .endedAt(interview.getInterviewOption().getEndedAt())
+                .build();
+    }
+}

--- a/src/main/java/cloudcomputinginha/demo/domain/InterviewOption.java
+++ b/src/main/java/cloudcomputinginha/demo/domain/InterviewOption.java
@@ -39,6 +39,7 @@ public class InterviewOption extends BaseEntity {
 
     private Integer answerTime;
 
+    @Column(nullable = false)
     private LocalDateTime scheduledAt;
 
     private LocalDateTime endedAt;

--- a/src/main/java/cloudcomputinginha/demo/domain/InterviewOption.java
+++ b/src/main/java/cloudcomputinginha/demo/domain/InterviewOption.java
@@ -45,4 +45,8 @@ public class InterviewOption extends BaseEntity {
 
     @OneToOne(mappedBy = "interviewOption", cascade = CascadeType.ALL)
     private Interview interview;
+
+    public void changeEndedAt(LocalDateTime endedAt) {
+        this.endedAt = endedAt;
+    }
 }

--- a/src/main/java/cloudcomputinginha/demo/repository/InterviewRepository.java
+++ b/src/main/java/cloudcomputinginha/demo/repository/InterviewRepository.java
@@ -4,4 +4,5 @@ import cloudcomputinginha.demo.domain.Interview;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface InterviewRepository extends JpaRepository<Interview, Long> {
+    Interview getReferenceWithInterviewOptionById(Long interviewId);
 }

--- a/src/main/java/cloudcomputinginha/demo/repository/MemberInterviewRepository.java
+++ b/src/main/java/cloudcomputinginha/demo/repository/MemberInterviewRepository.java
@@ -10,9 +10,11 @@ import java.util.Optional;
 public interface MemberInterviewRepository extends JpaRepository<MemberInterview, Long> {
     List<MemberInterview> interview(Interview interview);
 
-    Optional<MemberInterview> findByMemberIdAndInterviewId(Long memberId, Long interviewId);
+    List<MemberInterview> findByInterviewId(Long interviewId);
 
     boolean existsByMemberIdAndInterviewId(Long memberId, Long interviewId);
+
+    Optional<MemberInterview> findByMemberIdAndInterviewId(Long memberId, Long interviewId);
 
     Integer countMemberInterviewByInterviewId(Long id);
 }

--- a/src/main/java/cloudcomputinginha/demo/service/InterviewCommandService.java
+++ b/src/main/java/cloudcomputinginha/demo/service/InterviewCommandService.java
@@ -1,0 +1,8 @@
+package cloudcomputinginha.demo.service;
+
+import cloudcomputinginha.demo.domain.Interview;
+import cloudcomputinginha.demo.web.dto.InterviewRequestDTO;
+
+public interface InterviewCommandService {
+    Interview terminateInterview(Long interviewId, InterviewRequestDTO.endInterviewRequestDTO endInterviewRequestDTO);
+}

--- a/src/main/java/cloudcomputinginha/demo/service/InterviewCommandServiceImpl.java
+++ b/src/main/java/cloudcomputinginha/demo/service/InterviewCommandServiceImpl.java
@@ -1,6 +1,7 @@
 package cloudcomputinginha.demo.service;
 
 import cloudcomputinginha.demo.apiPayload.code.handler.InterviewHandler;
+import cloudcomputinginha.demo.apiPayload.code.status.ErrorStatus;
 import cloudcomputinginha.demo.domain.Interview;
 import cloudcomputinginha.demo.repository.InterviewRepository;
 import cloudcomputinginha.demo.web.dto.InterviewRequestDTO;
@@ -21,6 +22,11 @@ public class InterviewCommandServiceImpl implements InterviewCommandService {
     @Transactional
     public Interview terminateInterview(Long interviewId, InterviewRequestDTO.endInterviewRequestDTO endInterviewRequestDTO) {
         Interview interview = interviewRepository.getReferenceWithInterviewOptionById(interviewId);
+
+        if (interview.getInterviewOption().getEndedAt() != null) {
+            throw new InterviewHandler(ErrorStatus.INTERVIEW_ALREADY_TERMINATED);
+        }
+
 
         if (endInterviewRequestDTO.getEndedAt().isBefore(interview.getInterviewOption().getScheduledAt())) {
             throw new InterviewHandler(INTERVIEW_END_TIME_INVALID);

--- a/src/main/java/cloudcomputinginha/demo/service/MemberInterviewCommandService.java
+++ b/src/main/java/cloudcomputinginha/demo/service/MemberInterviewCommandService.java
@@ -7,4 +7,6 @@ public interface MemberInterviewCommandService {
     MemberInterview changeMemberInterviewStatus(Long interviewId, MemberInterviewRequestDTO.changeMemberStatusDTO memberInterviewRequestDTO);
 
     MemberInterview createMemberInterview(Long interviewId, MemberInterviewRequestDTO.createMemberInterviewDTO createMemberInterviewDTO);
+
+    void finalizeStatuses(Long interviewId);
 }

--- a/src/main/java/cloudcomputinginha/demo/service/MemberInterviewCommandServiceImpl.java
+++ b/src/main/java/cloudcomputinginha/demo/service/MemberInterviewCommandServiceImpl.java
@@ -5,11 +5,14 @@ import cloudcomputinginha.demo.apiPayload.code.handler.MemberInterviewHandler;
 import cloudcomputinginha.demo.apiPayload.code.status.ErrorStatus;
 import cloudcomputinginha.demo.converter.MemberInterviewConverter;
 import cloudcomputinginha.demo.domain.*;
+import cloudcomputinginha.demo.domain.enums.InterviewStatus;
 import cloudcomputinginha.demo.repository.*;
 import cloudcomputinginha.demo.web.dto.MemberInterviewRequestDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -66,5 +69,20 @@ public class MemberInterviewCommandServiceImpl implements MemberInterviewCommand
 
         MemberInterview memberInterview = MemberInterviewConverter.toMemberInterview(member, interview, resume, coverletter);
         return memberInterviewRepository.save(memberInterview);
+    }
+
+    @Override
+    public void finalizeStatuses(Long interviewId) {
+        List<MemberInterview> memberInterviews = memberInterviewRepository.findByInterviewId(interviewId);
+
+        for (MemberInterview mi : memberInterviews) {
+            switch (mi.getStatus()) {
+                case SCHEDULED -> mi.changeStatus(InterviewStatus.NO_SHOW);
+                case IN_PROGRESS -> mi.changeStatus(InterviewStatus.DONE);
+                default -> {
+                }
+            }
+        }
+
     }
 }

--- a/src/main/java/cloudcomputinginha/demo/web/controller/InterviewRestController.java
+++ b/src/main/java/cloudcomputinginha/demo/web/controller/InterviewRestController.java
@@ -1,0 +1,32 @@
+package cloudcomputinginha.demo.web.controller;
+
+
+import cloudcomputinginha.demo.apiPayload.ApiResponse;
+import cloudcomputinginha.demo.converter.InterviewConverter;
+import cloudcomputinginha.demo.domain.Interview;
+import cloudcomputinginha.demo.service.InterviewCommandService;
+import cloudcomputinginha.demo.validation.annotation.ExistInterview;
+import cloudcomputinginha.demo.web.dto.InterviewRequestDTO;
+import cloudcomputinginha.demo.web.dto.InterviewResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Tag(name = "인터뷰 API")
+@RequiredArgsConstructor
+public class InterviewRestController {
+    private final InterviewCommandService interviewCommandService;
+
+    @PatchMapping("/interviews/{interviewId}/end")
+    @Operation(summary = "면접 종료 API", description = "면접 종료 시간과 사용자 면접의 상태를 변경합니다.")
+    public ApiResponse<InterviewResponseDTO.InterviewEndResultDTO> terminateInterview(@PathVariable @ExistInterview Long interviewId, @RequestBody @Valid InterviewRequestDTO.endInterviewRequestDTO endInterviewRequestDTO) {
+        Interview interview = interviewCommandService.terminateInterview(interviewId, endInterviewRequestDTO);
+        return ApiResponse.onSuccess(InterviewConverter.toInterviewEndResultDTO(interview));
+    }
+}

--- a/src/main/java/cloudcomputinginha/demo/web/controller/MemberInterviewRestController.java
+++ b/src/main/java/cloudcomputinginha/demo/web/controller/MemberInterviewRestController.java
@@ -7,6 +7,7 @@ import cloudcomputinginha.demo.service.MemberInterviewCommandService;
 import cloudcomputinginha.demo.validation.annotation.ExistInterview;
 import cloudcomputinginha.demo.web.dto.MemberInterviewRequestDTO;
 import cloudcomputinginha.demo.web.dto.MemberInterviewResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -21,12 +22,14 @@ public class MemberInterviewRestController {
     private final MemberInterviewCommandService memberInterviewCommandService;
 
     @PatchMapping("/interviews/{interviewId}/waiting-room")
+    @Operation(summary = "면접 대기실 내 사용자의 상태를 변경하는 API", description = "면접, 사용자 id, 사용자 상태를 요청 받아 사용자 면접의 상태를 수정합니다.")
     public ApiResponse<MemberInterviewResponseDTO.MemberInterviewStatusDTO> changeParticipantsStatus(@PathVariable @ExistInterview Long interviewId, @RequestBody @Valid MemberInterviewRequestDTO.changeMemberStatusDTO changeMemberStatusDTO) {
         MemberInterview memberInterview = memberInterviewCommandService.changeMemberInterviewStatus(interviewId, changeMemberStatusDTO);
         return ApiResponse.onSuccess(MemberInterviewConverter.toMemberInterviewStatusDTO(memberInterview));
     }
 
     @PostMapping("/interviews/{interviewId}")
+    @Operation(summary = "면접 참여 신청 API", description = "면접, 사용자, 이력서, 자소서 id를 전부 받아와 사용자 면접을 생성합니다.")
     public ApiResponse<MemberInterviewResponseDTO.CreateMemberInterviewDTO> createMemberInterview(@PathVariable @ExistInterview Long interviewId, @RequestBody @Valid MemberInterviewRequestDTO.createMemberInterviewDTO createMemberInterviewDTO) {
         MemberInterview memberInterview = memberInterviewCommandService.createMemberInterview(interviewId, createMemberInterviewDTO);
         return ApiResponse.onSuccess(MemberInterviewConverter.toMemberInterviewResultDTO(memberInterview));

--- a/src/main/java/cloudcomputinginha/demo/web/dto/InterviewRequestDTO.java
+++ b/src/main/java/cloudcomputinginha/demo/web/dto/InterviewRequestDTO.java
@@ -1,0 +1,16 @@
+package cloudcomputinginha.demo.web.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+
+public class InterviewRequestDTO {
+    @Getter
+    public static class endInterviewRequestDTO {
+        @NotNull
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+        private LocalDateTime endedAt;
+    }
+}

--- a/src/main/java/cloudcomputinginha/demo/web/dto/InterviewResponseDTO.java
+++ b/src/main/java/cloudcomputinginha/demo/web/dto/InterviewResponseDTO.java
@@ -1,0 +1,16 @@
+package cloudcomputinginha.demo.web.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+public class InterviewResponseDTO {
+    @Builder
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    public static class InterviewEndResultDTO {
+        private Long interviewId;
+        private LocalDateTime endedAt;
+    }
+}


### PR DESCRIPTION
## ✨ 작업 개요
✨[CCI-30] 면접 종료 API

## ✅ 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
- 면접 옵션의 종료 시간을 기록하고
- 사용자 면접의 참석자와 미참석자의 최종 상태를 변경합니다.

## 📌 참고 사항(선택)
- API 명세서 참고

https://www.notion.so/1fccbf0e25ee8076b1eecd984920f48f?source=copy_link

## 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

## 🔗 관련 이슈
resolve #12 

<!--
## ✨ 작업 개요
회원가입 시 이메일 인증 기능 추가

## ✅ 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요.

- 회원가입 시 이메일 인증 요청 API 추가
- 인증 이메일 발송 기능 구현 (SMTP 기반)
- 이메일 인증 완료 시 계정 활성화 처리 로직 추가
- 관련 테스트 코드 작성 및 Postman 컬렉션 업데이트

📌 참고 사항(선택)
- Gmail SMTP를 사용하는 경우 보안 설정을 낮춰야 테스트가 가능합니다. 관련 문서는 위키에 정리해두었습니다.
- 이메일 템플릿은 기본 HTML로 구성했으며 추후 디자인 적용 예정입니다.

💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

- 이메일 인증 로직이 보안상 문제가 없는지 확인 부탁드립니다.
- 테스트 케이스가 충분한지도 검토 부탁드립니다.

🔗 관련 이슈
#42 회원가입 이메일 인증 기능
-->


[CCI-30]: https://cloudcomputinginha.atlassian.net/browse/CCI-30?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an API endpoint to end an interview, allowing users to specify the interview's end time.
  - Introduced new request and response formats for handling interview termination.
  - Enhanced interview status management, automatically updating participant statuses when an interview ends.

- **Bug Fixes**
  - Added validation to prevent setting an interview end time earlier than its start time.

- **Documentation**
  - Improved API documentation with detailed descriptions for relevant endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->