### PR TITLE
✨ [CCI-21] 자기소개서 생성, 리스트 조회, 세부 조회 API 

### DIFF
--- a/src/main/java/cloudcomputinginha/demo/converter/CoverletterConverter.java
+++ b/src/main/java/cloudcomputinginha/demo/converter/CoverletterConverter.java
@@ -5,6 +5,8 @@ import cloudcomputinginha.demo.domain.Member;
 import cloudcomputinginha.demo.web.dto.CoverletterRequestDTO;
 import cloudcomputinginha.demo.web.dto.CoverletterResponseDTO;
 
+import java.util.List;
+
 public class CoverletterConverter {
     public static Coverletter toCoverletter(CoverletterRequestDTO.createCoverletterDTO createCoverletterDTO, Member member) {
         return Coverletter.builder()
@@ -20,4 +22,20 @@ public class CoverletterConverter {
                 .createdAt(coverletter.getCreatedAt())
                 .build();
     }
+
+    public static CoverletterResponseDTO.MyCoverletterListDTO toMyCoverletterListDTO(List<Coverletter> coverletterList) {
+        List<CoverletterResponseDTO.MyCoverletterDTO> dtoList = coverletterList.stream()
+                .map(c -> CoverletterResponseDTO.MyCoverletterDTO.builder()
+                        .coverletterId(c.getId())
+                        .corporateName(c.getCorporateName())
+                        .jobName(c.getJobName())
+                        .createdAt(c.getCreatedAt())
+                        .build())
+                .toList();
+
+        return CoverletterResponseDTO.MyCoverletterListDTO.builder()
+                .coverletters(dtoList)
+                .build();
+    }
+
 }

--- a/src/main/java/cloudcomputinginha/demo/converter/CoverletterConverter.java
+++ b/src/main/java/cloudcomputinginha/demo/converter/CoverletterConverter.java
@@ -2,10 +2,13 @@ package cloudcomputinginha.demo.converter;
 
 import cloudcomputinginha.demo.domain.Coverletter;
 import cloudcomputinginha.demo.domain.Member;
+import cloudcomputinginha.demo.domain.Qna;
 import cloudcomputinginha.demo.web.dto.CoverletterRequestDTO;
 import cloudcomputinginha.demo.web.dto.CoverletterResponseDTO;
+import cloudcomputinginha.demo.web.dto.QnaResponseDTO;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class CoverletterConverter {
     public static Coverletter toCoverletter(CoverletterRequestDTO.createCoverletterDTO createCoverletterDTO, Member member) {
@@ -38,4 +41,17 @@ public class CoverletterConverter {
                 .build();
     }
 
+    public static CoverletterResponseDTO.CoverletterDetailDTO toDetailDTO(Coverletter coverletter, List<Qna> qnas) {
+        List<QnaResponseDTO.QnaDTO> qnaDTOs = qnas.stream()
+                .map(QnaConverter::toQnaDTO)
+                .collect(Collectors.toList());
+
+        return CoverletterResponseDTO.CoverletterDetailDTO.builder()
+                .coverletterId(coverletter.getId())
+                .corporateName(coverletter.getCorporateName())
+                .jobName(coverletter.getJobName())
+                .createdAt(coverletter.getCreatedAt())
+                .qnaList(qnaDTOs)
+                .build();
+    }
 }

--- a/src/main/java/cloudcomputinginha/demo/converter/CoverletterConverter.java
+++ b/src/main/java/cloudcomputinginha/demo/converter/CoverletterConverter.java
@@ -1,0 +1,23 @@
+package cloudcomputinginha.demo.converter;
+
+import cloudcomputinginha.demo.domain.Coverletter;
+import cloudcomputinginha.demo.domain.Member;
+import cloudcomputinginha.demo.web.dto.CoverletterRequestDTO;
+import cloudcomputinginha.demo.web.dto.CoverletterResponseDTO;
+
+public class CoverletterConverter {
+    public static Coverletter toCoverletter(CoverletterRequestDTO.createCoverletterDTO createCoverletterDTO, Member member) {
+        return Coverletter.builder()
+                .member(member)
+                .corporateName(createCoverletterDTO.getCorporateName())
+                .jobName(createCoverletterDTO.getJobName())
+                .build();
+    }
+
+    public static CoverletterResponseDTO.createCoverletterDTO toCreateCoverletterResponseDTO(Coverletter coverletter) {
+        return CoverletterResponseDTO.createCoverletterDTO.builder()
+                .coverletterId(coverletter.getId())
+                .createdAt(coverletter.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/cloudcomputinginha/demo/converter/QnaConverter.java
+++ b/src/main/java/cloudcomputinginha/demo/converter/QnaConverter.java
@@ -1,0 +1,15 @@
+package cloudcomputinginha.demo.converter;
+
+import cloudcomputinginha.demo.domain.Coverletter;
+import cloudcomputinginha.demo.domain.Qna;
+import cloudcomputinginha.demo.web.dto.QnaRequestDTO;
+
+public class QnaConverter {
+    public static Qna toQna(QnaRequestDTO.createQnaDTO createQnaDTO, Coverletter coverletter) {
+        return Qna.builder()
+                .coverletter(coverletter)
+                .question(createQnaDTO.getQuestion())
+                .answer(createQnaDTO.getAnswer())
+                .build();
+    }
+}

--- a/src/main/java/cloudcomputinginha/demo/converter/QnaConverter.java
+++ b/src/main/java/cloudcomputinginha/demo/converter/QnaConverter.java
@@ -3,6 +3,7 @@ package cloudcomputinginha.demo.converter;
 import cloudcomputinginha.demo.domain.Coverletter;
 import cloudcomputinginha.demo.domain.Qna;
 import cloudcomputinginha.demo.web.dto.QnaRequestDTO;
+import cloudcomputinginha.demo.web.dto.QnaResponseDTO;
 
 public class QnaConverter {
     public static Qna toQna(QnaRequestDTO.createQnaDTO createQnaDTO, Coverletter coverletter) {
@@ -10,6 +11,13 @@ public class QnaConverter {
                 .coverletter(coverletter)
                 .question(createQnaDTO.getQuestion())
                 .answer(createQnaDTO.getAnswer())
+                .build();
+    }
+
+    public static QnaResponseDTO.QnaDTO toQnaDTO(Qna qna) {
+        return QnaResponseDTO.QnaDTO.builder()
+                .question(qna.getQuestion())
+                .answer(qna.getQuestion())
                 .build();
     }
 }

--- a/src/main/java/cloudcomputinginha/demo/repository/CoverletterRepository.java
+++ b/src/main/java/cloudcomputinginha/demo/repository/CoverletterRepository.java
@@ -3,5 +3,8 @@ package cloudcomputinginha.demo.repository;
 import cloudcomputinginha.demo.domain.Coverletter;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CoverletterRepository extends JpaRepository<Coverletter, Long> {
+    public List<Coverletter> findAllByMemberId(Long memberId);
 }

--- a/src/main/java/cloudcomputinginha/demo/repository/QnaRepository.java
+++ b/src/main/java/cloudcomputinginha/demo/repository/QnaRepository.java
@@ -3,5 +3,8 @@ package cloudcomputinginha.demo.repository;
 import cloudcomputinginha.demo.domain.Qna;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface QnaRepository extends JpaRepository<Qna, Long> {
+    List<Qna> findAllByCoverletterId(Long coverletterId);
 }

--- a/src/main/java/cloudcomputinginha/demo/repository/QnaRepository.java
+++ b/src/main/java/cloudcomputinginha/demo/repository/QnaRepository.java
@@ -1,0 +1,7 @@
+package cloudcomputinginha.demo.repository;
+
+import cloudcomputinginha.demo.domain.Qna;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface QnaRepository extends JpaRepository<Qna, Long> {
+}

--- a/src/main/java/cloudcomputinginha/demo/service/CoverletterCommandService.java
+++ b/src/main/java/cloudcomputinginha/demo/service/CoverletterCommandService.java
@@ -1,0 +1,8 @@
+package cloudcomputinginha.demo.service;
+
+import cloudcomputinginha.demo.domain.Coverletter;
+import cloudcomputinginha.demo.web.dto.CoverletterRequestDTO;
+
+public interface CoverletterCommandService {
+    public Coverletter saveCoverletter(CoverletterRequestDTO.createCoverletterDTO coverletterDTO);
+}

--- a/src/main/java/cloudcomputinginha/demo/service/CoverletterCommandServiceImpl.java
+++ b/src/main/java/cloudcomputinginha/demo/service/CoverletterCommandServiceImpl.java
@@ -1,0 +1,40 @@
+package cloudcomputinginha.demo.service;
+
+import cloudcomputinginha.demo.converter.CoverletterConverter;
+import cloudcomputinginha.demo.converter.QnaConverter;
+import cloudcomputinginha.demo.domain.Coverletter;
+import cloudcomputinginha.demo.domain.Member;
+import cloudcomputinginha.demo.domain.Qna;
+import cloudcomputinginha.demo.repository.CoverletterRepository;
+import cloudcomputinginha.demo.repository.MemberRepository;
+import cloudcomputinginha.demo.repository.QnaRepository;
+import cloudcomputinginha.demo.web.dto.CoverletterRequestDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CoverletterCommandServiceImpl implements CoverletterCommandService {
+    private final MemberRepository memberRepository;
+    private final CoverletterRepository coverletterRepository;
+    private final QnaRepository qnaRepository;
+
+    @Override
+    public Coverletter saveCoverletter(CoverletterRequestDTO.createCoverletterDTO requestDTO) {
+        Member member = memberRepository.getReferenceById(requestDTO.getMemberId());
+        Coverletter coverletter = CoverletterConverter.toCoverletter(requestDTO, member);
+        coverletterRepository.save(coverletter);
+
+        List<Qna> qnaList = requestDTO.getQnaDTOList().stream()
+                .map(dto -> QnaConverter.toQna(dto, coverletter))
+                .toList();
+
+        qnaRepository.saveAll(qnaList);
+
+        return coverletter;
+    }
+}

--- a/src/main/java/cloudcomputinginha/demo/service/CoverletterQueryService.java
+++ b/src/main/java/cloudcomputinginha/demo/service/CoverletterQueryService.java
@@ -1,0 +1,9 @@
+package cloudcomputinginha.demo.service;
+
+import cloudcomputinginha.demo.domain.Coverletter;
+
+import java.util.List;
+
+public interface CoverletterQueryService {
+    List<Coverletter> findAllCoverletterByMember(Long memberId);
+}

--- a/src/main/java/cloudcomputinginha/demo/service/CoverletterQueryService.java
+++ b/src/main/java/cloudcomputinginha/demo/service/CoverletterQueryService.java
@@ -6,4 +6,6 @@ import java.util.List;
 
 public interface CoverletterQueryService {
     List<Coverletter> findAllCoverletterByMember(Long memberId);
+
+    Coverletter getCoverletter(Long coverletterId);
 }

--- a/src/main/java/cloudcomputinginha/demo/service/CoverletterQueryServiceImpl.java
+++ b/src/main/java/cloudcomputinginha/demo/service/CoverletterQueryServiceImpl.java
@@ -20,4 +20,9 @@ public class CoverletterQueryServiceImpl implements CoverletterQueryService {
     public List<Coverletter> findAllCoverletterByMember(Long memberId) {
         return coverletterRepository.findAllByMemberId(memberId);
     }
+
+    @Override
+    public Coverletter getCoverletter(Long coverletterId) {
+        return coverletterRepository.getReferenceById(coverletterId);
+    }
 }

--- a/src/main/java/cloudcomputinginha/demo/service/CoverletterQueryServiceImpl.java
+++ b/src/main/java/cloudcomputinginha/demo/service/CoverletterQueryServiceImpl.java
@@ -1,0 +1,23 @@
+package cloudcomputinginha.demo.service;
+
+import cloudcomputinginha.demo.domain.Coverletter;
+import cloudcomputinginha.demo.repository.CoverletterRepository;
+import cloudcomputinginha.demo.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class CoverletterQueryServiceImpl implements CoverletterQueryService {
+    private final CoverletterRepository coverletterRepository;
+    private final MemberRepository memberRepository;
+
+    @Override
+    public List<Coverletter> findAllCoverletterByMember(Long memberId) {
+        return coverletterRepository.findAllByMemberId(memberId);
+    }
+}

--- a/src/main/java/cloudcomputinginha/demo/service/QnaQueryService.java
+++ b/src/main/java/cloudcomputinginha/demo/service/QnaQueryService.java
@@ -1,0 +1,9 @@
+package cloudcomputinginha.demo.service;
+
+import cloudcomputinginha.demo.domain.Qna;
+
+import java.util.List;
+
+public interface QnaQueryService {
+    List<Qna> getQnasByCoverletter(Long coverletterId);
+}

--- a/src/main/java/cloudcomputinginha/demo/service/QnaQueryServiceImpl.java
+++ b/src/main/java/cloudcomputinginha/demo/service/QnaQueryServiceImpl.java
@@ -1,0 +1,21 @@
+package cloudcomputinginha.demo.service;
+
+import cloudcomputinginha.demo.domain.Qna;
+import cloudcomputinginha.demo.repository.QnaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class QnaQueryServiceImpl implements QnaQueryService {
+    private final QnaRepository qnaRepository;
+
+    @Override
+    public List<Qna> getQnasByCoverletter(Long coverletterId) {
+        return qnaRepository.findAllByCoverletterId(coverletterId);
+    }
+}

--- a/src/main/java/cloudcomputinginha/demo/web/controller/CoverletterRestController.java
+++ b/src/main/java/cloudcomputinginha/demo/web/controller/CoverletterRestController.java
@@ -4,16 +4,19 @@ import cloudcomputinginha.demo.apiPayload.ApiResponse;
 import cloudcomputinginha.demo.converter.CoverletterConverter;
 import cloudcomputinginha.demo.domain.Coverletter;
 import cloudcomputinginha.demo.service.CoverletterCommandService;
+import cloudcomputinginha.demo.service.CoverletterQueryService;
+import cloudcomputinginha.demo.validation.annotation.ExistMember;
 import cloudcomputinginha.demo.web.dto.CoverletterRequestDTO;
 import cloudcomputinginha.demo.web.dto.CoverletterResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Tag(name = "자기소개서 API")
 @RestController
@@ -22,11 +25,20 @@ import org.springframework.web.bind.annotation.RestController;
 @Validated
 public class CoverletterRestController {
     private final CoverletterCommandService coverletterCommandService;
+    private final CoverletterQueryService coverletterQueryService;
 
     @PostMapping
+    @Operation(summary = "자기소개서 생성")
     public ApiResponse<CoverletterResponseDTO.createCoverletterDTO> createCoverletter(@RequestBody @Valid CoverletterRequestDTO.createCoverletterDTO createCoverletterDTO) {
         Coverletter coverletter = coverletterCommandService.saveCoverletter(createCoverletterDTO);
         return ApiResponse.onSuccess(CoverletterConverter.toCreateCoverletterResponseDTO(coverletter));
+    }
+
+    @GetMapping("/me")
+    @Operation(summary = "나의 자기소개서 리스트 조회")
+    public ApiResponse<CoverletterResponseDTO.MyCoverletterListDTO> findMyCoverletter(@RequestParam @ExistMember @NotNull Long memberId) {
+        List<Coverletter> coverletterList = coverletterQueryService.findAllCoverletterByMember(memberId);
+        return ApiResponse.onSuccess(CoverletterConverter.toMyCoverletterListDTO(coverletterList));
     }
 }
 

--- a/src/main/java/cloudcomputinginha/demo/web/controller/CoverletterRestController.java
+++ b/src/main/java/cloudcomputinginha/demo/web/controller/CoverletterRestController.java
@@ -3,8 +3,11 @@ package cloudcomputinginha.demo.web.controller;
 import cloudcomputinginha.demo.apiPayload.ApiResponse;
 import cloudcomputinginha.demo.converter.CoverletterConverter;
 import cloudcomputinginha.demo.domain.Coverletter;
+import cloudcomputinginha.demo.domain.Qna;
 import cloudcomputinginha.demo.service.CoverletterCommandService;
 import cloudcomputinginha.demo.service.CoverletterQueryService;
+import cloudcomputinginha.demo.service.QnaQueryService;
+import cloudcomputinginha.demo.validation.annotation.ExistCoverletter;
 import cloudcomputinginha.demo.validation.annotation.ExistMember;
 import cloudcomputinginha.demo.web.dto.CoverletterRequestDTO;
 import cloudcomputinginha.demo.web.dto.CoverletterResponseDTO;
@@ -20,12 +23,13 @@ import java.util.List;
 
 @Tag(name = "자기소개서 API")
 @RestController
-@RequestMapping("/resumes")
+@RequestMapping("/coverletters")
 @RequiredArgsConstructor
 @Validated
 public class CoverletterRestController {
     private final CoverletterCommandService coverletterCommandService;
     private final CoverletterQueryService coverletterQueryService;
+    private final QnaQueryService qnaQueryService;
 
     @PostMapping
     @Operation(summary = "자기소개서 생성")
@@ -40,5 +44,15 @@ public class CoverletterRestController {
         List<Coverletter> coverletterList = coverletterQueryService.findAllCoverletterByMember(memberId);
         return ApiResponse.onSuccess(CoverletterConverter.toMyCoverletterListDTO(coverletterList));
     }
+
+    @GetMapping("/{coverletterId}")
+    @Operation(summary = "자기소개서 세부 조회")
+    public ApiResponse<CoverletterResponseDTO.CoverletterDetailDTO> getCoverletterDetail(@PathVariable @ExistCoverletter @NotNull Long coverletterId) {
+        Coverletter coverletter = coverletterQueryService.getCoverletter(coverletterId);
+        List<Qna> qnaList = qnaQueryService.getQnasByCoverletter(coverletterId);
+
+        return ApiResponse.onSuccess(CoverletterConverter.toDetailDTO(coverletter, qnaList));
+    }
+
 }
 

--- a/src/main/java/cloudcomputinginha/demo/web/controller/CoverletterRestController.java
+++ b/src/main/java/cloudcomputinginha/demo/web/controller/CoverletterRestController.java
@@ -1,0 +1,32 @@
+package cloudcomputinginha.demo.web.controller;
+
+import cloudcomputinginha.demo.apiPayload.ApiResponse;
+import cloudcomputinginha.demo.converter.CoverletterConverter;
+import cloudcomputinginha.demo.domain.Coverletter;
+import cloudcomputinginha.demo.service.CoverletterCommandService;
+import cloudcomputinginha.demo.web.dto.CoverletterRequestDTO;
+import cloudcomputinginha.demo.web.dto.CoverletterResponseDTO;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "자기소개서 API")
+@RestController
+@RequestMapping("/resumes")
+@RequiredArgsConstructor
+@Validated
+public class CoverletterRestController {
+    private final CoverletterCommandService coverletterCommandService;
+
+    @PostMapping
+    public ApiResponse<CoverletterResponseDTO.createCoverletterDTO> createCoverletter(@RequestBody @Valid CoverletterRequestDTO.createCoverletterDTO createCoverletterDTO) {
+        Coverletter coverletter = coverletterCommandService.saveCoverletter(createCoverletterDTO);
+        return ApiResponse.onSuccess(CoverletterConverter.toCreateCoverletterResponseDTO(coverletter));
+    }
+}
+

--- a/src/main/java/cloudcomputinginha/demo/web/dto/CoverletterRequestDTO.java
+++ b/src/main/java/cloudcomputinginha/demo/web/dto/CoverletterRequestDTO.java
@@ -1,0 +1,35 @@
+package cloudcomputinginha.demo.web.dto;
+
+import cloudcomputinginha.demo.validation.annotation.ExistMember;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+
+import java.util.List;
+
+public class CoverletterRequestDTO {
+    @Getter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    public static class createCoverletterDTO {
+        @ExistMember
+        @NotNull
+        private Long memberId;
+
+        @NotBlank
+        @Size(max = 100)
+        private String corporateName;
+
+        @NotBlank
+        @Size(max = 20)
+        private String jobName;
+
+        @NotEmpty
+        @Valid
+        private List<QnaRequestDTO.createQnaDTO> qnaDTOList;
+    }
+}

--- a/src/main/java/cloudcomputinginha/demo/web/dto/CoverletterResponseDTO.java
+++ b/src/main/java/cloudcomputinginha/demo/web/dto/CoverletterResponseDTO.java
@@ -3,6 +3,7 @@ package cloudcomputinginha.demo.web.dto;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class CoverletterResponseDTO {
     @Getter
@@ -11,6 +12,26 @@ public class CoverletterResponseDTO {
     @AllArgsConstructor
     public static class createCoverletterDTO {
         private Long coverletterId;
+        private LocalDateTime createdAt;
+    }
+
+
+    @Getter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    public static class MyCoverletterListDTO {
+        private List<MyCoverletterDTO> coverletters;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    public static class MyCoverletterDTO {
+        private Long coverletterId;
+        private String corporateName;
+        private String jobName;
         private LocalDateTime createdAt;
     }
 }

--- a/src/main/java/cloudcomputinginha/demo/web/dto/CoverletterResponseDTO.java
+++ b/src/main/java/cloudcomputinginha/demo/web/dto/CoverletterResponseDTO.java
@@ -34,4 +34,16 @@ public class CoverletterResponseDTO {
         private String jobName;
         private LocalDateTime createdAt;
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    public static class CoverletterDetailDTO {
+        private Long coverletterId;
+        private String corporateName;
+        private String jobName;
+        private LocalDateTime createdAt;
+        private List<QnaResponseDTO.QnaDTO> qnaList;
+    }
 }

--- a/src/main/java/cloudcomputinginha/demo/web/dto/CoverletterResponseDTO.java
+++ b/src/main/java/cloudcomputinginha/demo/web/dto/CoverletterResponseDTO.java
@@ -1,0 +1,16 @@
+package cloudcomputinginha.demo.web.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+public class CoverletterResponseDTO {
+    @Getter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    public static class createCoverletterDTO {
+        private Long coverletterId;
+        private LocalDateTime createdAt;
+    }
+}

--- a/src/main/java/cloudcomputinginha/demo/web/dto/QnaRequestDTO.java
+++ b/src/main/java/cloudcomputinginha/demo/web/dto/QnaRequestDTO.java
@@ -1,0 +1,17 @@
+package cloudcomputinginha.demo.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+public class QnaRequestDTO {
+    @Getter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    public static class createQnaDTO {
+        @NotBlank
+        private String question;
+        @NotBlank
+        private String answer;
+    }
+}

--- a/src/main/java/cloudcomputinginha/demo/web/dto/QnaResponseDTO.java
+++ b/src/main/java/cloudcomputinginha/demo/web/dto/QnaResponseDTO.java
@@ -1,0 +1,14 @@
+package cloudcomputinginha.demo.web.dto;
+
+import lombok.*;
+
+public class QnaResponseDTO {
+    @Getter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    public static class QnaDTO {
+        private String question;
+        private String answer;
+    }
+}


### PR DESCRIPTION
## ✨ 작업 개요
✨ [CCI-21] 자기소개서 생성, 리스트 조회, 세부 조회 API 

## ✅ 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
- 

## 📌 참고 사항(선택)
- 노션 API 명세서 참고해주세요!

## 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

## 🔗 관련 이슈
resolve #17 


<!--
## ✨ 작업 개요
회원가입 시 이메일 인증 기능 추가

## ✅ 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요.

- 회원가입 시 이메일 인증 요청 API 추가
- 인증 이메일 발송 기능 구현 (SMTP 기반)
- 이메일 인증 완료 시 계정 활성화 처리 로직 추가
- 관련 테스트 코드 작성 및 Postman 컬렉션 업데이트

📌 참고 사항(선택)
- Gmail SMTP를 사용하는 경우 보안 설정을 낮춰야 테스트가 가능합니다. 관련 문서는 위키에 정리해두었습니다.
- 이메일 템플릿은 기본 HTML로 구성했으며 추후 디자인 적용 예정입니다.

💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

- 이메일 인증 로직이 보안상 문제가 없는지 확인 부탁드립니다.
- 테스트 케이스가 충분한지도 검토 부탁드립니다.

🔗 관련 이슈
#42 회원가입 이메일 인증 기능
-->
