### PR TITLE
✨ [CCI-29] 면접 시작 API

### DIFF
--- a/src/main/java/cloudcomputinginha/demo/converter/InterviewOptionConverter.java
+++ b/src/main/java/cloudcomputinginha/demo/converter/InterviewOptionConverter.java
@@ -1,0 +1,16 @@
+package cloudcomputinginha.demo.converter;
+
+import cloudcomputinginha.demo.domain.InterviewOption;
+import cloudcomputinginha.demo.web.dto.InterviewOptionResponseDTO;
+
+public class InterviewOptionConverter {
+    public static InterviewOptionResponseDTO.InterviewOptionDTO toInterviewOptionDTO(InterviewOption interviewOption) {
+        return InterviewOptionResponseDTO.InterviewOptionDTO.builder()
+                .interviewFormat(interviewOption.getInterviewFormat())
+                .interviewType(interviewOption.getInterviewType())
+                .voiceType(interviewOption.getVoiceType())
+                .questionNumber(interviewOption.getQuestionNumber())
+                .answerTime(interviewOption.getAnswerTime())
+                .build();
+    }
+}

--- a/src/main/java/cloudcomputinginha/demo/converter/MemberInterviewConverter.java
+++ b/src/main/java/cloudcomputinginha/demo/converter/MemberInterviewConverter.java
@@ -3,6 +3,9 @@ package cloudcomputinginha.demo.converter;
 import cloudcomputinginha.demo.domain.*;
 import cloudcomputinginha.demo.web.dto.MemberInterviewResponseDTO;
 
+import java.util.List;
+import java.util.Map;
+
 public class MemberInterviewConverter {
     public static MemberInterviewResponseDTO.MemberInterviewStatusDTO toMemberInterviewStatusDTO(MemberInterview memberInterview) {
         return MemberInterviewResponseDTO.MemberInterviewStatusDTO.builder()
@@ -26,5 +29,24 @@ public class MemberInterviewConverter {
                 .memberInterviewId(memberInterview.getId())
                 .createdAt(memberInterview.getCreatedAt())
                 .build();
+    }
+
+    public static MemberInterviewResponseDTO.ParticipantDTO toParticipantDTO(MemberInterview memberInterview, List<Qna> qnas) {
+        return MemberInterviewResponseDTO.ParticipantDTO.builder()
+                .memberInterviewId(memberInterview.getId())
+                .resumeDTO(ResumeConverter.toResumeSimpleDTO(memberInterview.getResume()))
+                .coverLetterDTO(CoverletterConverter.toDetailDTO(memberInterview.getCoverletter(), qnas))
+                .build();
+    }
+
+    //참여자의 자기소개서 ID를 꺼내서 coverletterID에 해당하는 QNA 리스트를 가져온다.(해당 키가 없으면 빈 리스트 반환)
+    //반환된 QNA 리스트와 참여자 정보를 기반으로 응답용 DTO 생성
+    public static List<MemberInterviewResponseDTO.ParticipantDTO> toParticipantDTOs(List<MemberInterview> memberInterviews, Map<Long, List<Qna>> qnaMap) {
+        return memberInterviews.stream()
+                .map(mi -> {
+                    Long coverletterId = mi.getCoverletter().getId();
+                    List<Qna> qnas = qnaMap.getOrDefault(coverletterId, List.of());
+                    return MemberInterviewConverter.toParticipantDTO(mi, qnas);
+                }).toList();
     }
 }

--- a/src/main/java/cloudcomputinginha/demo/converter/ResumeConverter.java
+++ b/src/main/java/cloudcomputinginha/demo/converter/ResumeConverter.java
@@ -48,4 +48,11 @@ public class ResumeConverter {
                 .resumes(resumeList)
                 .build();
     }
+
+    public static ResumeResponseDTO.ResumeSimpleDTO toResumeSimpleDTO(Resume resume) {
+        return ResumeResponseDTO.ResumeSimpleDTO.builder()
+                .resumeId(resume.getId())
+                .fileUrl(resume.getFileUrl())
+                .build();
+    }
 }

--- a/src/main/java/cloudcomputinginha/demo/repository/MemberInterviewRepository.java
+++ b/src/main/java/cloudcomputinginha/demo/repository/MemberInterviewRepository.java
@@ -3,6 +3,7 @@ package cloudcomputinginha.demo.repository;
 import cloudcomputinginha.demo.domain.Interview;
 import cloudcomputinginha.demo.domain.MemberInterview;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -17,4 +18,9 @@ public interface MemberInterviewRepository extends JpaRepository<MemberInterview
     Optional<MemberInterview> findByMemberIdAndInterviewId(Long memberId, Long interviewId);
 
     Integer countMemberInterviewByInterviewId(Long id);
+
+    @Query("SELECT mi FROM MemberInterview mi " +
+            "JOIN FETCH mi.resume JOIN FETCH mi.coverletter JOIN FETCH mi.interview i " +
+            "WHERE i.id = :interviewId AND mi.status = 'IN_PROGRESS'")
+    List<MemberInterview> findInprogressByInterviewId(Long interviewId);
 }

--- a/src/main/java/cloudcomputinginha/demo/repository/QnaRepository.java
+++ b/src/main/java/cloudcomputinginha/demo/repository/QnaRepository.java
@@ -2,9 +2,14 @@ package cloudcomputinginha.demo.repository;
 
 import cloudcomputinginha.demo.domain.Qna;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
 public interface QnaRepository extends JpaRepository<Qna, Long> {
+    @Query("SELECT q FROM Qna q WHERE q.coverletter.id = :coverletterId")
     List<Qna> findAllByCoverletterId(Long coverletterId);
+
+    @Query("SELECT q FROM Qna q WHERE q.coverletter.id IN :coverletterIds")
+    List<Qna> findAllByCoverletterIds(List<Long> coverletterIds);
 }

--- a/src/main/java/cloudcomputinginha/demo/service/InterviewCommandService.java
+++ b/src/main/java/cloudcomputinginha/demo/service/InterviewCommandService.java
@@ -1,11 +1,13 @@
 package cloudcomputinginha.demo.service;
 
-import cloudcomputinginha.demo.converter.InterviewConverter;
 import cloudcomputinginha.demo.domain.Interview;
 import cloudcomputinginha.demo.web.dto.InterviewRequestDTO;
 import cloudcomputinginha.demo.web.dto.InterviewResponseDTO;
 
 public interface InterviewCommandService {
     Interview terminateInterview(Long interviewId, InterviewRequestDTO.endInterviewRequestDTO endInterviewRequestDTO);
+
     InterviewResponseDTO.InterviewCreateResultDTO createInterview(InterviewRequestDTO.InterviewCreateDTO request, Long memberId);
+
+    public InterviewResponseDTO.InterviewStartResponseDTO startInterview(Long interviewId);
 }

--- a/src/main/java/cloudcomputinginha/demo/web/controller/InterviewRestController.java
+++ b/src/main/java/cloudcomputinginha/demo/web/controller/InterviewRestController.java
@@ -11,27 +11,36 @@ import cloudcomputinginha.demo.web.dto.InterviewResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @Tag(name = "인터뷰 API")
 @RequiredArgsConstructor
+@RequestMapping("/interviews")
 public class InterviewRestController {
     private final InterviewCommandService interviewCommandService;
 
-    @PatchMapping("/interviews/{interviewId}/end")
+    @PatchMapping("/{interviewId}/end")
     @Operation(summary = "면접 종료 API", description = "면접 종료 시간과 사용자 면접의 상태를 변경합니다.")
     public ApiResponse<InterviewResponseDTO.InterviewEndResultDTO> terminateInterview(@PathVariable @ExistInterview Long interviewId, @RequestBody @Valid InterviewRequestDTO.endInterviewRequestDTO endInterviewRequestDTO) {
         Interview interview = interviewCommandService.terminateInterview(interviewId, endInterviewRequestDTO);
         return ApiResponse.onSuccess(InterviewConverter.toInterviewEndResultDTO(interview));
     }
 
-    @PostMapping("/interviews")
+    @PostMapping
     @Operation(summary = "면접 생성 API", description = "새로운 면접을 생성합니다.")
     public ApiResponse<InterviewResponseDTO.InterviewCreateResultDTO> createInterview(@RequestBody @Valid InterviewRequestDTO.InterviewCreateDTO request) {
         Long memberId = 1L;
         InterviewResponseDTO.InterviewCreateResultDTO result = interviewCommandService.createInterview(request, memberId);
         return ApiResponse.onSuccess(result);
+    }
+
+    @GetMapping("/{interviewId}/start")
+    @Operation(summary = "면접 시작 API", description = "해당 API가 호출되면 AI서버에게 넘겨줄 면접의 모든 정보를 넘겨줍니다.")
+    public ApiResponse<InterviewResponseDTO.InterviewStartResponseDTO> startInterview(@PathVariable @NotNull @ExistInterview Long interviewId) {
+        InterviewResponseDTO.InterviewStartResponseDTO interviewStartResponse = interviewCommandService.startInterview(interviewId);
+        return ApiResponse.onSuccess(interviewStartResponse);
     }
 }

--- a/src/main/java/cloudcomputinginha/demo/web/dto/CoverletterResponseDTO.java
+++ b/src/main/java/cloudcomputinginha/demo/web/dto/CoverletterResponseDTO.java
@@ -43,7 +43,7 @@ public class CoverletterResponseDTO {
         private Long coverletterId;
         private String corporateName;
         private String jobName;
-        private LocalDateTime createdAt;
         private List<QnaResponseDTO.QnaDTO> qnaList;
+        private LocalDateTime createdAt;
     }
 }

--- a/src/main/java/cloudcomputinginha/demo/web/dto/InterviewOptionResponseDTO.java
+++ b/src/main/java/cloudcomputinginha/demo/web/dto/InterviewOptionResponseDTO.java
@@ -1,0 +1,20 @@
+package cloudcomputinginha.demo.web.dto;
+
+import cloudcomputinginha.demo.domain.enums.InterviewFormat;
+import cloudcomputinginha.demo.domain.enums.InterviewType;
+import cloudcomputinginha.demo.domain.enums.VoiceType;
+import lombok.*;
+
+public class InterviewOptionResponseDTO {
+    @Getter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    public static class InterviewOptionDTO {
+        private InterviewFormat interviewFormat;
+        private InterviewType interviewType;
+        private VoiceType voiceType;
+        private int questionNumber;
+        private int answerTime;
+    }
+}

--- a/src/main/java/cloudcomputinginha/demo/web/dto/InterviewResponseDTO.java
+++ b/src/main/java/cloudcomputinginha/demo/web/dto/InterviewResponseDTO.java
@@ -6,6 +6,7 @@ import cloudcomputinginha.demo.domain.enums.StartType;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class InterviewResponseDTO {
     @Builder
@@ -32,5 +33,28 @@ public class InterviewResponseDTO {
         private StartType startType; // 즉시 or 예정
         private LocalDateTime startedAt; // 면접 시작 시간
         private LocalDateTime createdAt;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    public static class InterviewStartResponseDTO {
+        private Long interviewId;
+        private InterviewResponseDTO.InterviewDTO interview;
+        private InterviewOptionResponseDTO.InterviewOptionDTO options;
+        private List<MemberInterviewResponseDTO.ParticipantDTO> participants;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    public static class InterviewDTO {
+        private Long interviewId;
+        private String corporateName;
+        private String jobName;
+        private StartType startType;
+        private int participantCount;
     }
 }

--- a/src/main/java/cloudcomputinginha/demo/web/dto/MemberInterviewResponseDTO.java
+++ b/src/main/java/cloudcomputinginha/demo/web/dto/MemberInterviewResponseDTO.java
@@ -10,6 +10,16 @@ public class MemberInterviewResponseDTO {
     @Builder
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
     @AllArgsConstructor
+    public static class ParticipantDTO {
+        private Long memberInterviewId;
+        private ResumeResponseDTO.ResumeSimpleDTO resumeDTO;
+        private CoverletterResponseDTO.CoverletterDetailDTO coverLetterDTO;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
     public static class MemberInterviewStatusDTO {
         Long memberInterviewId;
         InterviewStatus status;

--- a/src/main/java/cloudcomputinginha/demo/web/dto/ResumeResponseDTO.java
+++ b/src/main/java/cloudcomputinginha/demo/web/dto/ResumeResponseDTO.java
@@ -57,4 +57,13 @@ public class ResumeResponseDTO {
     public static class ResumeListDTO {
         private List<ResumeDTO> resumes;
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    public static class ResumeSimpleDTO {
+        private Long resumeId;
+        private String fileUrl;
+    }
 }

--- a/src/main/resources/insert_dummy_data.sql
+++ b/src/main/resources/insert_dummy_data.sql
@@ -18,17 +18,17 @@ VALUES (1, '김민준', '01012345678', 'mj.kim@example.com', 'DEV', '안녕하�
 
 INSERT INTO interview_option (id, interview_format, interview_type, voice_type, question_number, answer_time,
                               created_at, updated_at)
-VALUES (1, 'ONE_TO_MANY', 'TECHNICAL', 'WOMEN_1', 3, 3, '2025-05-31 14:50:46', '2025-05-31 14:50:46'),
-       (2, 'ONE_TO_MANY', 'TECHNICAL', 'MEN_2', 4, 6, '2025-05-31 14:50:46', '2025-05-31 14:50:46'),
-       (3, 'ONE_TO_MANY', 'TECHNICAL', 'WOMEN_2', 3, 4, '2025-05-31 14:50:46', '2025-05-31 14:50:46');
+VALUES (1, 'GROUP', 'TECHNICAL', 'MALE30', 3, 3, '2025-05-31 14:50:46', '2025-05-31 14:50:46'),
+       (2, 'GROUP', 'TECHNICAL', 'MALE30', 4, 6, '2025-05-31 14:50:46', '2025-05-31 14:50:46'),
+       (3, 'GROUP', 'TECHNICAL', 'MALE30', 3, 4, '2025-05-31 14:50:46', '2025-05-31 14:50:46');
 
 INSERT INTO interview (interview_id, name, description, corporate_name, job_name, host_id, max_participants,
-                       is_open, interview_option_id, created_at, updated_at)
+                       is_open, interview_option_id, startType, created_at, updated_at)
 VALUES (1, '백엔드 기술 면접', '서버/DB 기술 관련 인터뷰', '카카오', '백엔드 개발자', 1, 4, False, 1,
-        '2025-05-31 14:50:46', '2025-05-31 14:50:46'),
+        '2025-05-31 14:50:46', 'NOW', '2025-05-31 14:50:46'),
        (2, '프론트엔드 기술 면접', 'React, Vue 등 프론트엔드 기술 검증', '네이버', '프론트엔드 개발자', 2, 4,
-        True, 2, '2025-05-31 14:50:46', '2025-05-31 14:50:46'),
-       (3, 'AI 실무 인터뷰', 'AI 모델 설계 및 적용 능력 검증', '토스', '데이터 엔지니어', 3, 2, False, 3,
+        True, 2, 'SCHEDULED', '2025-05-31 14:50:46', '2025-05-31 14:50:46'),
+       (3, 'AI 실무 인터뷰', 'AI 모델 설계 및 적용 능력 검증', '토스', '데이터 엔지니어', 3, 2, False, 3, 'SCHEDULED',
         '2025-05-31 14:50:46', '2025-05-31 14:50:46');
 
 INSERT INTO resume (resume_id, member_id, file_name, file_url, file_size, created_at, updated_at)


### PR DESCRIPTION
## ✨ 작업 개요
[✨ [CCI-29] 면접 시작 API]

## ✅ 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
- https://www.notion.so/1facbf0e25ee805c8bd4df555e38e62e?source=copy_link

## 📌 참고 사항(선택)
- 

## 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

## 🔗 관련 이슈


<!--
## ✨ 작업 개요
회원가입 시 이메일 인증 기능 추가

## ✅ 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요.

- 회원가입 시 이메일 인증 요청 API 추가
- 인증 이메일 발송 기능 구현 (SMTP 기반)
- 이메일 인증 완료 시 계정 활성화 처리 로직 추가
- 관련 테스트 코드 작성 및 Postman 컬렉션 업데이트

📌 참고 사항(선택)
- Gmail SMTP를 사용하는 경우 보안 설정을 낮춰야 테스트가 가능합니다. 관련 문서는 위키에 정리해두었습니다.
- 이메일 템플릿은 기본 HTML로 구성했으며 추후 디자인 적용 예정입니다.

💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

- 이메일 인증 로직이 보안상 문제가 없는지 확인 부탁드립니다.
- 테스트 케이스가 충분한지도 검토 부탁드립니다.

🔗 관련 이슈
#42 회원가입 이메일 인증 기능
-->


[CCI-29]: https://cloudcomputinginha.atlassian.net/browse/CCI-29?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new API endpoint to start an interview, providing comprehensive interview details, options, and participant information.
  - Expanded interview and participant data returned to include interview options, participant resumes, cover letters, and related QnA details.
  - Added new DTOs for interview options, interview metadata, participant details, and simplified resume information for richer responses.

- **Bug Fixes**
  - Updated endpoint paths for interview creation and termination for improved consistency.

- **Chores**
  - Updated sample data to reflect new interview option formats and start type values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->