### PR TITLE
✨[CCI-35] 일대다 면접 모집글 세부 조회 API

### DIFF
--- a/src/main/java/cloudcomputinginha/demo/converter/InterviewConverter.java
+++ b/src/main/java/cloudcomputinginha/demo/converter/InterviewConverter.java
@@ -115,4 +115,35 @@ public class InterviewConverter {
                 .participants(participantDTOs)
                 .build();
     }
+
+    public static InterviewResponseDTO.GroupInterviewDetailDTO toInterviewGroupDetailDTO(Interview interview, List<MemberInterview> memberInterviewList) {
+        return InterviewResponseDTO.GroupInterviewDetailDTO.builder()
+                .interviewId(interview.getId())
+                .name(interview.getName())
+                .description(interview.getDescription())
+                .sessionName(interview.getSessionName())
+                .jobName(interview.getJobName())
+                .interviewType(interview.getInterviewOption().getInterviewType())
+                .maxParticipants(interview.getMaxParticipants())
+                .currentParticipants(memberInterviewList.size())
+                .startedAt(interview.getStartedAt())
+                .hostName(
+                        memberInterviewList.stream()
+                                .filter(mi -> mi.getMember().getId().equals(interview.getHostId()))
+                                .findFirst()
+                                .map(mi -> mi.getMember().getName())
+                                .orElse("호스트의 이름을 알 수 없습니다.")
+                )
+                .groupInterviewParticipants(
+                        memberInterviewList.stream()
+                                .map(mi -> InterviewResponseDTO.GroupInterviewParticipantDTO.builder()
+                                        .memberId(mi.getMember().getId())
+                                        .name(mi.getMember().getName())
+                                        .isHost(mi.getMember().getId().equals(interview.getHostId()))
+                                        .isSubmitted(mi.getResume() != null && mi.getCoverletter() != null)
+                                        .build()
+                                ).toList()
+                )
+                .build();
+    }
 }

--- a/src/main/java/cloudcomputinginha/demo/service/InterviewQueryService.java
+++ b/src/main/java/cloudcomputinginha/demo/service/InterviewQueryService.java
@@ -5,4 +5,5 @@ import java.util.List;
 
 public interface InterviewQueryService {
     List<InterviewResponseDTO.InterviewGroupCardDTO> getGroupInterviewCards();
+    InterviewResponseDTO.GroupInterviewDetailDTO getGroupInterviewDetail(Long interviewId);
 }

--- a/src/main/java/cloudcomputinginha/demo/service/InterviewQueryServiceImpl.java
+++ b/src/main/java/cloudcomputinginha/demo/service/InterviewQueryServiceImpl.java
@@ -1,6 +1,13 @@
 package cloudcomputinginha.demo.service;
 
+import cloudcomputinginha.demo.apiPayload.code.handler.InterviewHandler;
+import cloudcomputinginha.demo.apiPayload.code.status.ErrorStatus;
+import cloudcomputinginha.demo.converter.InterviewConverter;
+import cloudcomputinginha.demo.domain.Interview;
+import cloudcomputinginha.demo.domain.MemberInterview;
 import cloudcomputinginha.demo.repository.InterviewQueryRepository;
+import cloudcomputinginha.demo.repository.InterviewRepository;
+import cloudcomputinginha.demo.repository.MemberInterviewRepository;
 import cloudcomputinginha.demo.web.dto.InterviewResponseDTO;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -11,10 +18,22 @@ import java.util.List;
 @RequiredArgsConstructor
 public class InterviewQueryServiceImpl implements InterviewQueryService {
     private final InterviewQueryRepository interviewQueryRepository;
+    private final InterviewRepository interviewRepository;
+    private final MemberInterviewRepository memberInterviewRepository;
 
     @Override
     @Transactional
     public List<InterviewResponseDTO.InterviewGroupCardDTO> getGroupInterviewCards() {
         return interviewQueryRepository.findGroupInterviewCards();
+    }
+
+    @Override
+    @Transactional
+    public InterviewResponseDTO.GroupInterviewDetailDTO getGroupInterviewDetail(Long interviewId) {
+        Interview interview = interviewRepository.findById(interviewId)
+                .orElseThrow(() -> new InterviewHandler(ErrorStatus.INTERVIEW_NOT_FOUND));
+
+        List<MemberInterview> memberInterviewList = memberInterviewRepository.findByInterviewId(interviewId);
+        return InterviewConverter.toInterviewGroupDetailDTO(interview, memberInterviewList);
     }
 }

--- a/src/main/java/cloudcomputinginha/demo/web/controller/InterviewRestController.java
+++ b/src/main/java/cloudcomputinginha/demo/web/controller/InterviewRestController.java
@@ -41,7 +41,7 @@ public class InterviewRestController {
         return ApiResponse.onSuccess(result);
     }
   
-    @GetMapping("/interviews/group")
+    @GetMapping("/group")
     @Operation(summary = "일대다 면접 모집글 조회 API", description = "일대다 면접 모집글을 조회합니다.")
     public ApiResponse<List<InterviewResponseDTO.InterviewGroupCardDTO>> getGroupInterviewCards() {
         List<InterviewResponseDTO.InterviewGroupCardDTO> result = interviewQueryService.getGroupInterviewCards();
@@ -53,5 +53,11 @@ public class InterviewRestController {
     public ApiResponse<InterviewResponseDTO.InterviewStartResponseDTO> startInterview(@PathVariable @NotNull @ExistInterview Long interviewId) {
         InterviewResponseDTO.InterviewStartResponseDTO interviewStartResponse = interviewCommandService.startInterview(interviewId);
         return ApiResponse.onSuccess(interviewStartResponse);
+    }
+
+    @GetMapping("/group/{interviewId}")
+    @Operation(summary = "일대다 면접 모집글 세부 조회 API", description = "일대다 면접 모집글 세부를 조회합니다.")
+    public ApiResponse<InterviewResponseDTO.GroupInterviewDetailDTO> getGroupInterviewDetail(@PathVariable @NotNull @ExistInterview Long interviewId) {
+        return ApiResponse.onSuccess(interviewQueryService.getGroupInterviewDetail(interviewId));
     }
 }

--- a/src/main/java/cloudcomputinginha/demo/web/dto/InterviewResponseDTO.java
+++ b/src/main/java/cloudcomputinginha/demo/web/dto/InterviewResponseDTO.java
@@ -48,6 +48,7 @@ public class InterviewResponseDTO {
         private InterviewType interviewType;
         private int currentParticipants;
         private int maxParticipants;
+        private LocalDateTime startedAt;
     }
 
     @Getter
@@ -71,5 +72,36 @@ public class InterviewResponseDTO {
         private String jobName;
         private StartType startType;
         private int participantCount;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    public static class GroupInterviewDetailDTO {
+        private Long interviewId;
+        private String name;
+        private String description;
+        private String sessionName;
+        private String jobName;
+
+        private InterviewType interviewType;
+        private int maxParticipants;
+        private int currentParticipants;
+        private LocalDateTime startedAt;
+
+        private String hostName;
+        private List<GroupInterviewParticipantDTO> groupInterviewParticipants;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    public static class GroupInterviewParticipantDTO {
+        private Long memberId; // 참가자 id
+        private String name; // 그룹 면접 참가자 이름
+        private boolean isHost; // 참가자가 호스트인지 여부
+        private boolean isSubmitted; // 참가자가 자료를 제출했는지 여부
     }
 }


### PR DESCRIPTION
## ✨ 작업 개요
일대다 면접 모집글 세부를 조회합니다.

## ✅ 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
- 일대다 면접 모집글 세부 조회

## 📌 참고 사항(선택)
- 해당 API 명세서는 추후 노션에 추가하도록 하겠습니다.

## 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

## 🔗 관련 이슈
#28 

<!--
## ✨ 작업 개요
회원가입 시 이메일 인증 기능 추가

## ✅ 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요.

- 회원가입 시 이메일 인증 요청 API 추가
- 인증 이메일 발송 기능 구현 (SMTP 기반)
- 이메일 인증 완료 시 계정 활성화 처리 로직 추가
- 관련 테스트 코드 작성 및 Postman 컬렉션 업데이트

📌 참고 사항(선택)
- Gmail SMTP를 사용하는 경우 보안 설정을 낮춰야 테스트가 가능합니다. 관련 문서는 위키에 정리해두었습니다.
- 이메일 템플릿은 기본 HTML로 구성했으며 추후 디자인 적용 예정입니다.

💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

- 이메일 인증 로직이 보안상 문제가 없는지 확인 부탁드립니다.
- 테스트 케이스가 충분한지도 검토 부탁드립니다.

🔗 관련 이슈
#42 회원가입 이메일 인증 기능
-->
