### PR TITLE
✨[CCI-32] 면접 수정 API

### DIFF
--- a/src/main/java/cloudcomputinginha/demo/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/cloudcomputinginha/demo/apiPayload/code/status/ErrorStatus.java
@@ -37,6 +37,7 @@ public enum ErrorStatus implements BaseErrorCode {
     INTERVIEW_NOT_ACCEPTING_MEMBERS(HttpStatus.BAD_REQUEST, "INTERVIEW4002", "현재 인터뷰는 참여자를 받지 않습니다."),
     INTERVIEW_END_TIME_INVALID(HttpStatus.CONFLICT, "INTERVIEW4003", "인터뷰의 종료 시간이 시작 시간보다 빠릅니다."),
     INTERVIEW_ALREADY_TERMINATED(HttpStatus.CONFLICT, "INTERVIEW4004", "해당하는 인터뷰는 이미 종료되었습니다."),
+    INTERVIEW_NO_PERMISSION(HttpStatus.FORBIDDEN, "INTERVIEW4005", "해당 인터뷰 수정 권한이 없습니다."),
 
     // 멤버 인터뷰 관련 에러,
     INTERVIEW_STATUS_INVALID(HttpStatus.BAD_REQUEST, "MEMBERINTERVIEW4001", "올바른 인터뷰 상태가 아닙니다."),

--- a/src/main/java/cloudcomputinginha/demo/converter/InterviewConverter.java
+++ b/src/main/java/cloudcomputinginha/demo/converter/InterviewConverter.java
@@ -146,4 +146,14 @@ public class InterviewConverter {
                 )
                 .build();
     }
+
+    public static InterviewResponseDTO.InterviewUpdateResponseDTO toInterviewUpdateResponseDTO(Interview interview) {
+        return InterviewResponseDTO.InterviewUpdateResponseDTO.builder()
+                .interviewId(interview.getId())
+                .name(interview.getName())
+                .description(interview.getDescription())
+                .maxParticipants(interview.getMaxParticipants())
+                .isOpen(interview.getIsOpen())
+                .build();
+    }
 }

--- a/src/main/java/cloudcomputinginha/demo/domain/Interview.java
+++ b/src/main/java/cloudcomputinginha/demo/domain/Interview.java
@@ -59,4 +59,20 @@ public class Interview extends BaseEntity {
     public void changeEndedAt(LocalDateTime endedAt) {
         this.endedAt = endedAt;
     }
+
+    public void updateName(String name){
+        this.name = name;
+    }
+
+    public void updateDescription(String description){
+        this.description = description;
+    }
+
+    public void updateMaxParticipants(Integer maxParticipants){
+        this.maxParticipants = maxParticipants;
+    }
+
+    public void updateIsOpen(Boolean isOpen){
+        this.isOpen = isOpen;
+    }
 }

--- a/src/main/java/cloudcomputinginha/demo/service/InterviewCommandService.java
+++ b/src/main/java/cloudcomputinginha/demo/service/InterviewCommandService.java
@@ -10,4 +10,6 @@ public interface InterviewCommandService {
     InterviewResponseDTO.InterviewCreateResultDTO createInterview(InterviewRequestDTO.InterviewCreateDTO request, Long memberId);
 
     public InterviewResponseDTO.InterviewStartResponseDTO startInterview(Long interviewId);
+
+    InterviewResponseDTO.InterviewUpdateResponseDTO updateInterview(Long memberId, Long interviewId, InterviewRequestDTO.InterviewUpdateDTO request);
 }

--- a/src/main/java/cloudcomputinginha/demo/web/controller/InterviewRestController.java
+++ b/src/main/java/cloudcomputinginha/demo/web/controller/InterviewRestController.java
@@ -60,4 +60,11 @@ public class InterviewRestController {
     public ApiResponse<InterviewResponseDTO.GroupInterviewDetailDTO> getGroupInterviewDetail(@PathVariable @NotNull @ExistInterview Long interviewId) {
         return ApiResponse.onSuccess(interviewQueryService.getGroupInterviewDetail(interviewId));
     }
+
+    @PatchMapping("/{interviewId}")
+    @Operation(summary = "면접 수정 API", description = "면접 이름, 설명, 최대 인원, 공개 여부를 수정합니다.")
+    public ApiResponse<InterviewResponseDTO.InterviewUpdateResponseDTO> updateInterview(@RequestParam Long memberId, @PathVariable Long interviewId, @RequestBody @Valid InterviewRequestDTO.InterviewUpdateDTO request) {
+        InterviewResponseDTO.InterviewUpdateResponseDTO result = interviewCommandService.updateInterview(memberId, interviewId, request);
+        return ApiResponse.onSuccess(result);
+    }
 }

--- a/src/main/java/cloudcomputinginha/demo/web/dto/InterviewRequestDTO.java
+++ b/src/main/java/cloudcomputinginha/demo/web/dto/InterviewRequestDTO.java
@@ -79,4 +79,17 @@ public class InterviewRequestDTO {
         private Long id;
         private String email;
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class InterviewUpdateDTO {
+        @NotBlank
+        private String name;
+        @NotBlank
+        private String description;
+        private Integer maxParticipants;
+        private Boolean isOpen;
+    }
 }

--- a/src/main/java/cloudcomputinginha/demo/web/dto/InterviewResponseDTO.java
+++ b/src/main/java/cloudcomputinginha/demo/web/dto/InterviewResponseDTO.java
@@ -104,4 +104,16 @@ public class InterviewResponseDTO {
         private boolean isHost; // 참가자가 호스트인지 여부
         private boolean isSubmitted; // 참가자가 자료를 제출했는지 여부
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    public static class InterviewUpdateResponseDTO {
+        private Long interviewId;
+        private String name;
+        private String description;
+        private Integer maxParticipants;
+        private boolean isOpen;
+    }
 }


### PR DESCRIPTION
## ✨ 작업 개요
면접을 수정합니다.

## ✅ 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
- 면접 수정 API (면접 이름, 설명, 최대 인원, 공개 여부 수정 가능)

## 📌 참고 사항(선택)
- 일대다 면접의 경우 4가지 컬럼 모두 수정
- 일대일 면접의 경우 최대 인원과 공개 여부는 지우고 실행

## 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

## 🔗 관련 이슈
#30 

<!--
## ✨ 작업 개요
회원가입 시 이메일 인증 기능 추가

## ✅ 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요.

- 회원가입 시 이메일 인증 요청 API 추가
- 인증 이메일 발송 기능 구현 (SMTP 기반)
- 이메일 인증 완료 시 계정 활성화 처리 로직 추가
- 관련 테스트 코드 작성 및 Postman 컬렉션 업데이트

📌 참고 사항(선택)
- Gmail SMTP를 사용하는 경우 보안 설정을 낮춰야 테스트가 가능합니다. 관련 문서는 위키에 정리해두었습니다.
- 이메일 템플릿은 기본 HTML로 구성했으며 추후 디자인 적용 예정입니다.

💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

- 이메일 인증 로직이 보안상 문제가 없는지 확인 부탁드립니다.
- 테스트 케이스가 충분한지도 검토 부탁드립니다.

🔗 관련 이슈
#42 회원가입 이메일 인증 기능
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to update interview details (name, description, maximum participants, and visibility) via a new PATCH endpoint.
  - Introduced request and response formats for updating interviews, improving clarity and consistency for users.
- **Bug Fixes**
  - Added a specific error message for users without permission to modify an interview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->