### PR TITLE
✨[CCI-33] 면접 옵션 수정 API

### DIFF
--- a/src/main/java/cloudcomputinginha/demo/converter/InterviewOptionConverter.java
+++ b/src/main/java/cloudcomputinginha/demo/converter/InterviewOptionConverter.java
@@ -2,12 +2,23 @@ package cloudcomputinginha.demo.converter;
 
 import cloudcomputinginha.demo.domain.InterviewOption;
 import cloudcomputinginha.demo.web.dto.InterviewOptionResponseDTO;
+import cloudcomputinginha.demo.web.dto.InterviewResponseDTO;
 
 public class InterviewOptionConverter {
     public static InterviewOptionResponseDTO.InterviewOptionDTO toInterviewOptionDTO(InterviewOption interviewOption) {
         return InterviewOptionResponseDTO.InterviewOptionDTO.builder()
                 .interviewFormat(interviewOption.getInterviewFormat())
                 .interviewType(interviewOption.getInterviewType())
+                .voiceType(interviewOption.getVoiceType())
+                .questionNumber(interviewOption.getQuestionNumber())
+                .answerTime(interviewOption.getAnswerTime())
+                .build();
+    }
+
+    public static InterviewOptionResponseDTO.InterviewOptionUpdateResponseDTO toInterviewOptionUpdateResponseDTO(InterviewOption interviewOption) {
+        return InterviewOptionResponseDTO.InterviewOptionUpdateResponseDTO.builder()
+                .interviewId(interviewOption.getInterview().getId())
+                .interviewOptionId(interviewOption.getId())
                 .voiceType(interviewOption.getVoiceType())
                 .questionNumber(interviewOption.getQuestionNumber())
                 .answerTime(interviewOption.getAnswerTime())

--- a/src/main/java/cloudcomputinginha/demo/domain/InterviewOption.java
+++ b/src/main/java/cloudcomputinginha/demo/domain/InterviewOption.java
@@ -43,4 +43,15 @@ public class InterviewOption extends BaseEntity {
     @OneToOne(mappedBy = "interviewOption", cascade = CascadeType.ALL)
     private Interview interview;
 
+    public void updateVoiceType(VoiceType voiceType) {
+        this.voiceType = voiceType;
+    }
+
+    public void updateQuestionNumber(Integer questionNumber) {
+        this.questionNumber = questionNumber;
+    }
+
+    public void updateAnswerTime(Integer answerTime) {
+        this.answerTime = answerTime;
+    }
 }

--- a/src/main/java/cloudcomputinginha/demo/service/InterviewOptionCommandService.java
+++ b/src/main/java/cloudcomputinginha/demo/service/InterviewOptionCommandService.java
@@ -1,0 +1,8 @@
+package cloudcomputinginha.demo.service;
+
+import cloudcomputinginha.demo.web.dto.InterviewOptionRequestDTO;
+import cloudcomputinginha.demo.web.dto.InterviewOptionResponseDTO;
+
+public interface InterviewOptionCommandService {
+    InterviewOptionResponseDTO.InterviewOptionUpdateResponseDTO updateInterviewOption(Long memberId, Long interviewId, InterviewOptionRequestDTO.InterviewOptionUpdateDTO request);
+}

--- a/src/main/java/cloudcomputinginha/demo/service/InterviewOptionCommandServiceImpl.java
+++ b/src/main/java/cloudcomputinginha/demo/service/InterviewOptionCommandServiceImpl.java
@@ -1,0 +1,45 @@
+package cloudcomputinginha.demo.service;
+
+import cloudcomputinginha.demo.apiPayload.code.handler.InterviewHandler;
+import cloudcomputinginha.demo.apiPayload.code.status.ErrorStatus;
+import cloudcomputinginha.demo.converter.InterviewOptionConverter;
+import cloudcomputinginha.demo.domain.Interview;
+import cloudcomputinginha.demo.repository.InterviewRepository;
+import cloudcomputinginha.demo.web.dto.InterviewOptionRequestDTO;
+import cloudcomputinginha.demo.web.dto.InterviewOptionResponseDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class InterviewOptionCommandServiceImpl implements InterviewOptionCommandService {
+
+    private final InterviewRepository interviewRepository;
+
+    @Override
+    @Transactional
+    public InterviewOptionResponseDTO.InterviewOptionUpdateResponseDTO updateInterviewOption(Long memberId, Long interviewId, InterviewOptionRequestDTO.InterviewOptionUpdateDTO request) {
+        Interview interview = interviewRepository.findById(interviewId)
+                .orElseThrow(() -> new InterviewHandler(ErrorStatus.INTERVIEW_NOT_FOUND));
+
+        if (!interview.getHostId().equals(memberId)) {
+            throw new InterviewHandler(ErrorStatus.INTERVIEW_NO_PERMISSION);
+        }
+
+        if (interview.getStartedAt().isBefore(LocalDateTime.now())) {
+            throw new InterviewHandler(ErrorStatus.INTERVIEW_ALREADY_TERMINATED);
+        }
+
+        interview.getInterviewOption().updateVoiceType(request.getVoiceType());
+        interview.getInterviewOption().updateQuestionNumber(request.getQuestionNumber());
+        interview.getInterviewOption().updateAnswerTime(request.getAnswerTime());
+
+        return InterviewOptionConverter.toInterviewOptionUpdateResponseDTO(interview.getInterviewOption());
+    }
+}

--- a/src/main/java/cloudcomputinginha/demo/web/controller/InterviewRestController.java
+++ b/src/main/java/cloudcomputinginha/demo/web/controller/InterviewRestController.java
@@ -5,8 +5,11 @@ import cloudcomputinginha.demo.apiPayload.ApiResponse;
 import cloudcomputinginha.demo.converter.InterviewConverter;
 import cloudcomputinginha.demo.domain.Interview;
 import cloudcomputinginha.demo.service.InterviewCommandService;
+import cloudcomputinginha.demo.service.InterviewOptionCommandService;
 import cloudcomputinginha.demo.service.InterviewQueryService;
 import cloudcomputinginha.demo.validation.annotation.ExistInterview;
+import cloudcomputinginha.demo.web.dto.InterviewOptionRequestDTO;
+import cloudcomputinginha.demo.web.dto.InterviewOptionResponseDTO;
 import cloudcomputinginha.demo.web.dto.InterviewRequestDTO;
 import cloudcomputinginha.demo.web.dto.InterviewResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
@@ -25,6 +28,7 @@ import java.util.List;
 public class InterviewRestController {
     private final InterviewCommandService interviewCommandService;
     private final InterviewQueryService interviewQueryService;
+    private final InterviewOptionCommandService interviewOptionCommandService;
 
     @PatchMapping("/{interviewId}/end")
     @Operation(summary = "면접 종료 API", description = "면접 종료 시간과 사용자 면접의 상태를 변경합니다.")
@@ -65,6 +69,13 @@ public class InterviewRestController {
     @Operation(summary = "면접 수정 API", description = "면접 이름, 설명, 최대 인원, 공개 여부를 수정합니다.")
     public ApiResponse<InterviewResponseDTO.InterviewUpdateResponseDTO> updateInterview(@RequestParam Long memberId, @PathVariable Long interviewId, @RequestBody @Valid InterviewRequestDTO.InterviewUpdateDTO request) {
         InterviewResponseDTO.InterviewUpdateResponseDTO result = interviewCommandService.updateInterview(memberId, interviewId, request);
+        return ApiResponse.onSuccess(result);
+    }
+
+    @PatchMapping("/{interviewId}/option")
+    @Operation(summary = "면접 옵션 수정 API", description = "목소리 유형, 최대 질문 개수, 답변 가능 시간을 수정합니다.")
+    public ApiResponse<InterviewOptionResponseDTO.InterviewOptionUpdateResponseDTO> updateInterviewOption(@RequestParam Long memberId, @PathVariable Long interviewId, @RequestBody @Valid InterviewOptionRequestDTO.InterviewOptionUpdateDTO request) {
+        InterviewOptionResponseDTO.InterviewOptionUpdateResponseDTO result = interviewOptionCommandService.updateInterviewOption(memberId, interviewId, request);
         return ApiResponse.onSuccess(result);
     }
 }

--- a/src/main/java/cloudcomputinginha/demo/web/dto/InterviewOptionRequestDTO.java
+++ b/src/main/java/cloudcomputinginha/demo/web/dto/InterviewOptionRequestDTO.java
@@ -1,0 +1,23 @@
+package cloudcomputinginha.demo.web.dto;
+
+import cloudcomputinginha.demo.domain.enums.VoiceType;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class InterviewOptionRequestDTO {
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class InterviewOptionUpdateDTO {
+        @NotNull
+        private VoiceType voiceType;
+        @NotNull
+        private Integer questionNumber;
+        @NotNull
+        private Integer answerTime;
+    }
+}

--- a/src/main/java/cloudcomputinginha/demo/web/dto/InterviewOptionResponseDTO.java
+++ b/src/main/java/cloudcomputinginha/demo/web/dto/InterviewOptionResponseDTO.java
@@ -17,4 +17,16 @@ public class InterviewOptionResponseDTO {
         private int questionNumber;
         private int answerTime;
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    public static class InterviewOptionUpdateResponseDTO {
+        private Long interviewId;
+        private Long interviewOptionId;
+        private VoiceType voiceType;
+        private Integer questionNumber;
+        private Integer answerTime;
+    }
 }

--- a/src/main/java/cloudcomputinginha/demo/web/dto/InterviewResponseDTO.java
+++ b/src/main/java/cloudcomputinginha/demo/web/dto/InterviewResponseDTO.java
@@ -3,6 +3,7 @@ package cloudcomputinginha.demo.web.dto;
 import cloudcomputinginha.demo.domain.enums.InterviewFormat;
 import cloudcomputinginha.demo.domain.enums.InterviewType;
 import cloudcomputinginha.demo.domain.enums.StartType;
+import cloudcomputinginha.demo.domain.enums.VoiceType;
 import lombok.*;
 
 import java.time.LocalDateTime;


### PR DESCRIPTION
## ✨ 작업 개요
면접 옵션을 수정합니다.

## ✅ 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
- 면접 옵션 (목소리 유형, 최대 질문 개수, 답변 가능 시간) 수정 API

## 📌 참고 사항(선택)
- 해당 API 명세서는 추후 노션에 추가하도록 하겠습니다.

## 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

## 🔗 관련 이슈
#33 

<!--
## ✨ 작업 개요
회원가입 시 이메일 인증 기능 추가

## ✅ 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요.

- 회원가입 시 이메일 인증 요청 API 추가
- 인증 이메일 발송 기능 구현 (SMTP 기반)
- 이메일 인증 완료 시 계정 활성화 처리 로직 추가
- 관련 테스트 코드 작성 및 Postman 컬렉션 업데이트

📌 참고 사항(선택)
- Gmail SMTP를 사용하는 경우 보안 설정을 낮춰야 테스트가 가능합니다. 관련 문서는 위키에 정리해두었습니다.
- 이메일 템플릿은 기본 HTML로 구성했으며 추후 디자인 적용 예정입니다.

💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

- 이메일 인증 로직이 보안상 문제가 없는지 확인 부탁드립니다.
- 테스트 케이스가 충분한지도 검토 부탁드립니다.

🔗 관련 이슈
#42 회원가입 이메일 인증 기능
-->
