### PR TITLE
🐛[CCI-41]: S3 Put PresignedUrl API 수정

### DIFF
--- a/src/main/java/cloudcomputinginha/demo/service/S3PresignedService.java
+++ b/src/main/java/cloudcomputinginha/demo/service/S3PresignedService.java
@@ -6,7 +6,6 @@ import cloudcomputinginha.demo.web.dto.ResumeResponseDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
@@ -32,19 +31,16 @@ public class S3PresignedService {
 
 
         String key = "resumes/" + UUID.randomUUID() + "_" + fileName;
-        String fileUrl = "https://" + bucketName + ".s3." + region + ".amazonaws.com/" + key;
+        String fileUrl = "https://" + bucketName + ".s3." + ".amazonaws.com/" + key;
+
+        PutObjectRequest objectRequest = PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(key)
+                .build();
 
         PresignedPutObjectRequest presignedRequest = s3Presigner.presignPutObject(
-                req -> req.signatureDuration(Duration.ofMinutes(15))
-                        .putObjectRequest(
-                                PutObjectRequest.builder()
-                                        .bucket(bucketName)
-                                        .key(key)
-                                        .contentType("application/pdf")
-                                        .acl(ObjectCannedACL.PUBLIC_READ)
-                                        .build()
-                        )
-        );
+                b -> b.signatureDuration(Duration.ofMinutes(5))
+                        .putObjectRequest(objectRequest));
 
         return new ResumeResponseDTO.PresignedUploadDTO(presignedRequest.url().toString(), key, fileUrl);
     }


### PR DESCRIPTION
## ✨ 작업 개요
🐛 FIX: S3 Put PresignedUrl API 수정

## ✅ 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
- 응답 DTO의 fileUrl이 PresignedReqeust.url()과 동일하도록 수정했습니다.
-  실제 생성된 PresignedUrl을 바탕으로 이력서를 Put했을 때, 403 SignatureMismatch 오류가 발생하는 것을 확인했습니다.
   이는 S3 bucket의 모든 퍼블릭 엑세스 차단이 비활성 상태임에도 불구하고 
   ACL(PUBLIC_READ) 관련 PutRequest를 날려서 발생하는 것이었습니다.
   따라서 서비스 코드 중 ACL 관련 설정 코드를 삭제합니다.

## 📌 참고 사항(선택)
- EC2 인스턴스의 IAM Role을 사용하여 자동 인증 받는 방식으로 PresignedUrl을 생성했습니다.
  **따라서 로컬 환경 테스트가 불가능하고 EC2 인스턴스에서 작동할 때 정상적으로 동작합니다.** 
- API 명세서
https://www.notion.so/S3-PreSignedURL-1fccbf0e25ee800986aae47fe7e9e52f?source=copy_link

## 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

## 🔗 관련 이슈
close #35 

<!--
## ✨ 작업 개요
회원가입 시 이메일 인증 기능 추가

## ✅ 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요.

- 회원가입 시 이메일 인증 요청 API 추가
- 인증 이메일 발송 기능 구현 (SMTP 기반)
- 이메일 인증 완료 시 계정 활성화 처리 로직 추가
- 관련 테스트 코드 작성 및 Postman 컬렉션 업데이트

📌 참고 사항(선택)
- Gmail SMTP를 사용하는 경우 보안 설정을 낮춰야 테스트가 가능합니다. 관련 문서는 위키에 정리해두었습니다.
- 이메일 템플릿은 기본 HTML로 구성했으며 추후 디자인 적용 예정입니다.

💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

- 이메일 인증 로직이 보안상 문제가 없는지 확인 부탁드립니다.
- 테스트 케이스가 충분한지도 검토 부탁드립니다.

🔗 관련 이슈
#42 회원가입 이메일 인증 기능
-->
