### PR TITLE
✨[CCI-24] 나의 면접 리스트 조회(페이징 X)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,5 +38,4 @@ out/
 
 ### 팀 노션 스페이스 참고 ###
 /src/main/resources/application.yml
-
-
+/src/main/resources/keystore.p12

--- a/src/main/java/cloudcomputinginha/demo/converter/InterviewConverter.java
+++ b/src/main/java/cloudcomputinginha/demo/converter/InterviewConverter.java
@@ -156,4 +156,17 @@ public class InterviewConverter {
                 .isOpen(interview.getIsOpen())
                 .build();
     }
+
+    public static InterviewResponseDTO.InterviewCardDTO toInterviewCardDTO(Interview interview) {
+        return InterviewResponseDTO.InterviewCardDTO.builder()
+                .interviewId(interview.getId())
+                .name(interview.getName())
+                .corporateName(interview.getCorporateName())
+                .jobName(interview.getJobName())
+                .currentParticipants(interview.getCurrentParticipants())
+                .maxParticipants(interview.getMaxParticipants())
+                .startedAt(interview.getStartedAt())
+                .endedAt(interview.getEndedAt())
+                .build();
+    }
 }

--- a/src/main/java/cloudcomputinginha/demo/converter/InterviewConverter.java
+++ b/src/main/java/cloudcomputinginha/demo/converter/InterviewConverter.java
@@ -79,7 +79,7 @@ public class InterviewConverter {
                 .sessionName(interview.getSessionName())
                 .jobName(interview.getJobName())
                 .interviewType(interview.getInterviewOption().getInterviewType())
-                .currentParticipants(interview.getCurrentParticipants())
+                .currentParticipants(interview.getCurrentParticipants().intValue())
                 .maxParticipants(interview.getMaxParticipants())
                 .startedAt(interview.getStartedAt())
                 .build();
@@ -125,7 +125,7 @@ public class InterviewConverter {
                 .jobName(interview.getJobName())
                 .interviewType(interview.getInterviewOption().getInterviewType())
                 .maxParticipants(interview.getMaxParticipants())
-                .currentParticipants(interview.getCurrentParticipants())
+                .currentParticipants(interview.getCurrentParticipants().intValue())
                 .startedAt(interview.getStartedAt())
                 .hostName(
                         memberInterviewList.stream()
@@ -163,7 +163,7 @@ public class InterviewConverter {
                 .name(interview.getName())
                 .corporateName(interview.getCorporateName())
                 .jobName(interview.getJobName())
-                .currentParticipants(interview.getCurrentParticipants())
+                .currentParticipants(interview.getCurrentParticipants().intValue())
                 .maxParticipants(interview.getMaxParticipants())
                 .startedAt(interview.getStartedAt())
                 .endedAt(interview.getEndedAt())

--- a/src/main/java/cloudcomputinginha/demo/converter/InterviewConverter.java
+++ b/src/main/java/cloudcomputinginha/demo/converter/InterviewConverter.java
@@ -71,7 +71,7 @@ public class InterviewConverter {
         return LocalDateTime.parse(request.getScheduledDate() + "T" + request.getScheduledTime() + ":00");
     }
 
-    public static InterviewResponseDTO.InterviewGroupCardDTO toInterviewGroupCardDTO(Interview interview, int currentParticipants) {
+    public static InterviewResponseDTO.InterviewGroupCardDTO toInterviewGroupCardDTO(Interview interview) {
         return InterviewResponseDTO.InterviewGroupCardDTO.builder()
                 .interviewId(interview.getId())
                 .name(interview.getName())
@@ -79,7 +79,7 @@ public class InterviewConverter {
                 .sessionName(interview.getSessionName())
                 .jobName(interview.getJobName())
                 .interviewType(interview.getInterviewOption().getInterviewType())
-                .currentParticipants(currentParticipants)
+                .currentParticipants(interview.getCurrentParticipants())
                 .maxParticipants(interview.getMaxParticipants())
                 .startedAt(interview.getStartedAt())
                 .build();
@@ -105,7 +105,7 @@ public class InterviewConverter {
                 .collect(Collectors.groupingBy(q -> q.getCoverletter().getId()));
 
         InterviewResponseDTO.InterviewDTO interviewDTO = InterviewConverter.toInterviewDTO(interview, memberInterviews.size());
-        InterviewOptionResponseDTO.InterviewOptionDTO interviewOptionDTO = InterviewOptionConverter.toInterviewOptionDTO(interview.getInterviewOption());
+        InterviewOptionResponseDTO.InterviewOptionDetailDTO interviewOptionDTO = InterviewOptionConverter.toInterviewOptionDTO(interview.getInterviewOption());
         List<MemberInterviewResponseDTO.ParticipantDTO> participantDTOs = MemberInterviewConverter.toParticipantDTOs(memberInterviews, qnaMap);
 
         return InterviewResponseDTO.InterviewStartResponseDTO.builder()
@@ -125,7 +125,7 @@ public class InterviewConverter {
                 .jobName(interview.getJobName())
                 .interviewType(interview.getInterviewOption().getInterviewType())
                 .maxParticipants(interview.getMaxParticipants())
-                .currentParticipants(memberInterviewList.size())
+                .currentParticipants(interview.getCurrentParticipants())
                 .startedAt(interview.getStartedAt())
                 .hostName(
                         memberInterviewList.stream()

--- a/src/main/java/cloudcomputinginha/demo/converter/InterviewOptionConverter.java
+++ b/src/main/java/cloudcomputinginha/demo/converter/InterviewOptionConverter.java
@@ -23,4 +23,11 @@ public class InterviewOptionConverter {
                 .answerTime(interviewOption.getAnswerTime())
                 .build();
     }
+
+    public static InterviewOptionResponseDTO.InterviewOptionPreviewDTO toInterviewOptionPreviewDTO(InterviewOption option) {
+        return InterviewOptionResponseDTO.InterviewOptionPreviewDTO.builder()
+                .interviewFormat(option.getInterviewFormat())
+                .interviewType(option.getInterviewType())
+                .build();
+    }
 }

--- a/src/main/java/cloudcomputinginha/demo/converter/InterviewOptionConverter.java
+++ b/src/main/java/cloudcomputinginha/demo/converter/InterviewOptionConverter.java
@@ -2,11 +2,10 @@ package cloudcomputinginha.demo.converter;
 
 import cloudcomputinginha.demo.domain.InterviewOption;
 import cloudcomputinginha.demo.web.dto.InterviewOptionResponseDTO;
-import cloudcomputinginha.demo.web.dto.InterviewResponseDTO;
 
 public class InterviewOptionConverter {
-    public static InterviewOptionResponseDTO.InterviewOptionDTO toInterviewOptionDTO(InterviewOption interviewOption) {
-        return InterviewOptionResponseDTO.InterviewOptionDTO.builder()
+    public static InterviewOptionResponseDTO.InterviewOptionDetailDTO toInterviewOptionDTO(InterviewOption interviewOption) {
+        return InterviewOptionResponseDTO.InterviewOptionDetailDTO.builder()
                 .interviewFormat(interviewOption.getInterviewFormat())
                 .interviewType(interviewOption.getInterviewType())
                 .voiceType(interviewOption.getVoiceType())

--- a/src/main/java/cloudcomputinginha/demo/converter/MemberInterviewConverter.java
+++ b/src/main/java/cloudcomputinginha/demo/converter/MemberInterviewConverter.java
@@ -49,4 +49,22 @@ public class MemberInterviewConverter {
                     return MemberInterviewConverter.toParticipantDTO(mi, qnas);
                 }).toList();
     }
+
+    public static MemberInterviewResponseDTO.MyInterviewListDTO toMyInterviewListDTO(List<MemberInterview> myInterviews) {
+        List<MemberInterviewResponseDTO.MyInterviewDTO> myInterviewDTOS = myInterviews.stream()
+                .map(MemberInterviewConverter::toMyInterviewDTO)
+                .toList();
+        return new MemberInterviewResponseDTO.MyInterviewListDTO(myInterviewDTOS);
+    }
+
+    public static MemberInterviewResponseDTO.MyInterviewDTO toMyInterviewDTO(MemberInterview memberInterview) {
+        Interview interview = memberInterview.getInterview();
+        InterviewOption option = interview.getInterviewOption();
+
+        return MemberInterviewResponseDTO.MyInterviewDTO.builder()
+                .myInterviewCardDTO(InterviewConverter.toInterviewCardDTO(interview))
+                .interviewOptionPreviewDTO(InterviewOptionConverter.toInterviewOptionPreviewDTO(option))
+                .memberInterviewStatusDTO(MemberInterviewConverter.toMemberInterviewStatusDTO(memberInterview))
+                .build();
+    }
 }

--- a/src/main/java/cloudcomputinginha/demo/domain/Interview.java
+++ b/src/main/java/cloudcomputinginha/demo/domain/Interview.java
@@ -43,6 +43,9 @@ public class Interview extends BaseEntity {
     private Long hostId;
 
     @Builder.Default
+    private Integer currentParticipants = 1;
+
+    @Builder.Default
     private Integer maxParticipants = 1; //일대일 면접을 기준으로 초기화
 
     @Builder.Default
@@ -60,19 +63,23 @@ public class Interview extends BaseEntity {
         this.endedAt = endedAt;
     }
 
-    public void updateName(String name){
+    public void updateName(String name) {
         this.name = name;
     }
 
-    public void updateDescription(String description){
+    public void updateDescription(String description) {
         this.description = description;
     }
 
-    public void updateMaxParticipants(Integer maxParticipants){
+    public void updateMaxParticipants(Integer maxParticipants) {
         this.maxParticipants = maxParticipants;
     }
 
-    public void updateIsOpen(Boolean isOpen){
+    public void updateIsOpen(Boolean isOpen) {
         this.isOpen = isOpen;
+    }
+
+    public void increaseCurrentParticipants() {
+        this.currentParticipants++;
     }
 }

--- a/src/main/java/cloudcomputinginha/demo/repository/MemberInterviewRepository.java
+++ b/src/main/java/cloudcomputinginha/demo/repository/MemberInterviewRepository.java
@@ -17,8 +17,6 @@ public interface MemberInterviewRepository extends JpaRepository<MemberInterview
 
     Optional<MemberInterview> findByMemberIdAndInterviewId(Long memberId, Long interviewId);
 
-    Integer countMemberInterviewByInterviewId(Long id);
-
     @Query("SELECT mi FROM MemberInterview mi " +
             "JOIN FETCH mi.resume JOIN FETCH mi.coverletter JOIN FETCH mi.interview i " +
             "WHERE i.id = :interviewId AND mi.status = 'IN_PROGRESS'")

--- a/src/main/java/cloudcomputinginha/demo/repository/MemberInterviewRepository.java
+++ b/src/main/java/cloudcomputinginha/demo/repository/MemberInterviewRepository.java
@@ -21,4 +21,9 @@ public interface MemberInterviewRepository extends JpaRepository<MemberInterview
             "JOIN FETCH mi.resume JOIN FETCH mi.coverletter JOIN FETCH mi.interview i " +
             "WHERE i.id = :interviewId AND mi.status = 'IN_PROGRESS'")
     List<MemberInterview> findInprogressByInterviewId(Long interviewId);
+
+    @Query("SELECT mi FROM MemberInterview mi " +
+            "JOIN FETCH mi.interview i JOIN FETCH i.interviewOption o " +
+            "WHERE mi.member.id = :memberId ORDER BY i.startedAt DESC ")
+    List<MemberInterview> findAllForMyPage(Long memberId);
 }

--- a/src/main/java/cloudcomputinginha/demo/service/MemberInterviewCommandServiceImpl.java
+++ b/src/main/java/cloudcomputinginha/demo/service/MemberInterviewCommandServiceImpl.java
@@ -47,8 +47,8 @@ public class MemberInterviewCommandServiceImpl implements MemberInterviewCommand
         if (!interview.getIsOpen()) {
             throw new MemberInterviewHandler(ErrorStatus.INTERVIEW_NOT_ACCEPTING_MEMBERS);
         }
-        if (interview.getMaxParticipants() <= memberInterviewRepository.countMemberInterviewByInterviewId(interview.getId())) {
-            throw new MemberInterviewHandler(ErrorStatus.INTERVIEW_CAPACITY_EXCEEDED); //
+        if (interview.getMaxParticipants() <= interview.getCurrentParticipants()) {
+            throw new MemberInterviewHandler(ErrorStatus.INTERVIEW_CAPACITY_EXCEEDED);
         }
 
         Resume resume = null;
@@ -68,6 +68,7 @@ public class MemberInterviewCommandServiceImpl implements MemberInterviewCommand
         }
 
         MemberInterview memberInterview = MemberInterviewConverter.toMemberInterview(member, interview, resume, coverletter);
+        interview.increaseCurrentParticipants();
         return memberInterviewRepository.save(memberInterview);
     }
 

--- a/src/main/java/cloudcomputinginha/demo/service/MemberInterviewCommandServiceImpl.java
+++ b/src/main/java/cloudcomputinginha/demo/service/MemberInterviewCommandServiceImpl.java
@@ -47,9 +47,6 @@ public class MemberInterviewCommandServiceImpl implements MemberInterviewCommand
         if (!interview.getIsOpen()) {
             throw new MemberInterviewHandler(ErrorStatus.INTERVIEW_NOT_ACCEPTING_MEMBERS);
         }
-        if (interview.getMaxParticipants() <= interview.getCurrentParticipants()) {
-            throw new MemberInterviewHandler(ErrorStatus.INTERVIEW_CAPACITY_EXCEEDED);
-        }
 
         Resume resume = null;
         if (createMemberInterviewDTO.getResumeId() != null) {
@@ -68,7 +65,7 @@ public class MemberInterviewCommandServiceImpl implements MemberInterviewCommand
         }
 
         MemberInterview memberInterview = MemberInterviewConverter.toMemberInterview(member, interview, resume, coverletter);
-        interview.increaseCurrentParticipants();
+        interview.increaseCurrentParticipants(); //이 메서드 내부에서 동시성을 보호하고, 정원이 넘치면 예외를 발생시킵니다.
         return memberInterviewRepository.save(memberInterview);
     }
 

--- a/src/main/java/cloudcomputinginha/demo/service/MemberInterviewQueryService.java
+++ b/src/main/java/cloudcomputinginha/demo/service/MemberInterviewQueryService.java
@@ -1,0 +1,9 @@
+package cloudcomputinginha.demo.service;
+
+import cloudcomputinginha.demo.domain.MemberInterview;
+
+import java.util.List;
+
+public interface MemberInterviewQueryService {
+    List<MemberInterview> getMyInterviews(Long memberId);
+}

--- a/src/main/java/cloudcomputinginha/demo/service/MemberInterviewQueryServiceImpl.java
+++ b/src/main/java/cloudcomputinginha/demo/service/MemberInterviewQueryServiceImpl.java
@@ -1,0 +1,21 @@
+package cloudcomputinginha.demo.service;
+
+import cloudcomputinginha.demo.domain.MemberInterview;
+import cloudcomputinginha.demo.repository.MemberInterviewRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MemberInterviewQueryServiceImpl implements MemberInterviewQueryService {
+    private final MemberInterviewRepository memberInterviewRepository;
+
+    @Override
+    public List<MemberInterview> getMyInterviews(Long memberId) {
+        return memberInterviewRepository.findAllForMyPage(memberId);
+    }
+}

--- a/src/main/java/cloudcomputinginha/demo/web/controller/InterviewRestController.java
+++ b/src/main/java/cloudcomputinginha/demo/web/controller/InterviewRestController.java
@@ -44,7 +44,7 @@ public class InterviewRestController {
         InterviewResponseDTO.InterviewCreateResultDTO result = interviewCommandService.createInterview(request, memberId);
         return ApiResponse.onSuccess(result);
     }
-  
+
     @GetMapping("/group")
     @Operation(summary = "일대다 면접 모집글 조회 API", description = "일대다 면접 모집글을 조회합니다.")
     public ApiResponse<List<InterviewResponseDTO.InterviewGroupCardDTO>> getGroupInterviewCards() {
@@ -52,7 +52,7 @@ public class InterviewRestController {
         return ApiResponse.onSuccess(result);
     }
 
-    @GetMapping("/{interviewId}/start")
+    //@GetMapping("/{interviewId}/start")
     @Operation(summary = "면접 시작 API", description = "해당 API가 호출되면 AI서버에게 넘겨줄 면접의 모든 정보를 넘겨줍니다.")
     public ApiResponse<InterviewResponseDTO.InterviewStartResponseDTO> startInterview(@PathVariable @NotNull @ExistInterview Long interviewId) {
         InterviewResponseDTO.InterviewStartResponseDTO interviewStartResponse = interviewCommandService.startInterview(interviewId);

--- a/src/main/java/cloudcomputinginha/demo/web/controller/MemberInterviewRestController.java
+++ b/src/main/java/cloudcomputinginha/demo/web/controller/MemberInterviewRestController.java
@@ -4,18 +4,20 @@ import cloudcomputinginha.demo.apiPayload.ApiResponse;
 import cloudcomputinginha.demo.converter.MemberInterviewConverter;
 import cloudcomputinginha.demo.domain.MemberInterview;
 import cloudcomputinginha.demo.service.MemberInterviewCommandService;
+import cloudcomputinginha.demo.service.MemberInterviewQueryService;
 import cloudcomputinginha.demo.validation.annotation.ExistInterview;
+import cloudcomputinginha.demo.validation.annotation.ExistMember;
 import cloudcomputinginha.demo.web.dto.MemberInterviewRequestDTO;
 import cloudcomputinginha.demo.web.dto.MemberInterviewResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Validated
 @RestController
@@ -23,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class MemberInterviewRestController {
     private final MemberInterviewCommandService memberInterviewCommandService;
+    private final MemberInterviewQueryService memberInterviewQueryService;
 
     //@PatchMapping("/interviews/{interviewId}/waiting-room")
     @Operation(summary = "면접 대기실 내 사용자의 상태를 변경하는 API", description = "면접, 사용자 id, 사용자 상태를 요청 받아 사용자 면접의 상태를 수정합니다.")
@@ -36,6 +39,13 @@ public class MemberInterviewRestController {
     public ApiResponse<MemberInterviewResponseDTO.CreateMemberInterviewDTO> createMemberInterview(@PathVariable @ExistInterview Long interviewId, @RequestBody @Valid MemberInterviewRequestDTO.createMemberInterviewDTO createMemberInterviewDTO) {
         MemberInterview memberInterview = memberInterviewCommandService.createMemberInterview(interviewId, createMemberInterviewDTO);
         return ApiResponse.onSuccess(MemberInterviewConverter.toMemberInterviewResultDTO(memberInterview));
+    }
+
+    @GetMapping("/mypage/interviews")
+    @Operation(summary = "나의 면접 리스트 조회 API", description = "나의 면접 리스트를 조회합니다.(상태 구분, 페이징 X)")
+    public ApiResponse<MemberInterviewResponseDTO.MyInterviewListDTO> getMyInterviews(@RequestParam @NotNull @ExistMember Long memberId) {
+        List<MemberInterview> myInterviews = memberInterviewQueryService.getMyInterviews(memberId);
+        return ApiResponse.onSuccess(MemberInterviewConverter.toMyInterviewListDTO(myInterviews));
     }
 
 }

--- a/src/main/java/cloudcomputinginha/demo/web/controller/MemberInterviewRestController.java
+++ b/src/main/java/cloudcomputinginha/demo/web/controller/MemberInterviewRestController.java
@@ -12,7 +12,10 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
 
 @Validated
 @RestController
@@ -21,7 +24,7 @@ import org.springframework.web.bind.annotation.*;
 public class MemberInterviewRestController {
     private final MemberInterviewCommandService memberInterviewCommandService;
 
-    @PatchMapping("/interviews/{interviewId}/waiting-room")
+    //@PatchMapping("/interviews/{interviewId}/waiting-room")
     @Operation(summary = "면접 대기실 내 사용자의 상태를 변경하는 API", description = "면접, 사용자 id, 사용자 상태를 요청 받아 사용자 면접의 상태를 수정합니다.")
     public ApiResponse<MemberInterviewResponseDTO.MemberInterviewStatusDTO> changeParticipantsStatus(@PathVariable @ExistInterview Long interviewId, @RequestBody @Valid MemberInterviewRequestDTO.changeMemberStatusDTO changeMemberStatusDTO) {
         MemberInterview memberInterview = memberInterviewCommandService.changeMemberInterviewStatus(interviewId, changeMemberStatusDTO);
@@ -34,5 +37,5 @@ public class MemberInterviewRestController {
         MemberInterview memberInterview = memberInterviewCommandService.createMemberInterview(interviewId, createMemberInterviewDTO);
         return ApiResponse.onSuccess(MemberInterviewConverter.toMemberInterviewResultDTO(memberInterview));
     }
-    
+
 }

--- a/src/main/java/cloudcomputinginha/demo/web/dto/InterviewOptionResponseDTO.java
+++ b/src/main/java/cloudcomputinginha/demo/web/dto/InterviewOptionResponseDTO.java
@@ -10,7 +10,16 @@ public class InterviewOptionResponseDTO {
     @Builder
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
     @AllArgsConstructor
-    public static class InterviewOptionDTO {
+    public static class InterviewOptionPreviewDTO {
+        private InterviewFormat interviewFormat;
+        private InterviewType interviewType;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    public static class InterviewOptionDetailDTO {
         private InterviewFormat interviewFormat;
         private InterviewType interviewType;
         private VoiceType voiceType;

--- a/src/main/java/cloudcomputinginha/demo/web/dto/InterviewResponseDTO.java
+++ b/src/main/java/cloudcomputinginha/demo/web/dto/InterviewResponseDTO.java
@@ -116,4 +116,19 @@ public class InterviewResponseDTO {
         private Integer maxParticipants;
         private boolean isOpen;
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    public static class InterviewCardDTO {
+        private Long interviewId;
+        private String name;
+        private String corporateName;
+        private String jobName;
+        private Integer currentParticipants;
+        private Integer maxParticipants;
+        private LocalDateTime startedAt;
+        private LocalDateTime endedAt;
+    }
 }

--- a/src/main/java/cloudcomputinginha/demo/web/dto/InterviewResponseDTO.java
+++ b/src/main/java/cloudcomputinginha/demo/web/dto/InterviewResponseDTO.java
@@ -3,7 +3,6 @@ package cloudcomputinginha.demo.web.dto;
 import cloudcomputinginha.demo.domain.enums.InterviewFormat;
 import cloudcomputinginha.demo.domain.enums.InterviewType;
 import cloudcomputinginha.demo.domain.enums.StartType;
-import cloudcomputinginha.demo.domain.enums.VoiceType;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -59,7 +58,7 @@ public class InterviewResponseDTO {
     public static class InterviewStartResponseDTO {
         private Long interviewId;
         private InterviewResponseDTO.InterviewDTO interview;
-        private InterviewOptionResponseDTO.InterviewOptionDTO options;
+        private InterviewOptionResponseDTO.InterviewOptionDetailDTO options;
         private List<MemberInterviewResponseDTO.ParticipantDTO> participants;
     }
 

--- a/src/main/java/cloudcomputinginha/demo/web/dto/MemberInterviewResponseDTO.java
+++ b/src/main/java/cloudcomputinginha/demo/web/dto/MemberInterviewResponseDTO.java
@@ -4,6 +4,7 @@ import cloudcomputinginha.demo.domain.enums.InterviewStatus;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class MemberInterviewResponseDTO {
     @Getter
@@ -33,5 +34,31 @@ public class MemberInterviewResponseDTO {
     public static class CreateMemberInterviewDTO {
         Long memberInterviewId;
         LocalDateTime createdAt;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    public static class MyInterviewListDTO {
+        List<MyInterviewDTO> myInterviews;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    public static class MyInterviewDTO {
+        /*
+        - 인터뷰
+            - 인터뷰 id, 이름, 회사, 직무명, 현재 인원, 최대 인원, 면접 예정 시각, 종료 시각 //InterviewCardDTO
+        - 인터뷰 옵션
+            - 인터뷰 포멧, 인터뷰 타입 //InterviewOptionPreviewDTO
+        - 멤버 인터뷰
+            - 멤버 인터뷰 id, 상태 //ParticipantDTO
+         */
+        private InterviewResponseDTO.InterviewCardDTO myInterviewCardDTO;
+        private InterviewOptionResponseDTO.InterviewOptionPreviewDTO interviewOptionPreviewDTO;
+        private MemberInterviewStatusDTO memberInterviewStatusDTO;
     }
 }

--- a/src/main/resources/insert_dummy_data.sql
+++ b/src/main/resources/insert_dummy_data.sql
@@ -23,9 +23,9 @@ VALUES (1, 'GROUP', 'TECHNICAL', 'MALE30', 3, 3, '2025-05-31 14:50:46', '2025-05
        (3, 'GROUP', 'TECHNICAL', 'MALE30', 3, 4, '2025-05-31 14:50:46', '2025-05-31 14:50:46');
 
 INSERT INTO interview (interview_id, name, description, corporate_name, job_name, host_id, max_participants,
-                       is_open, interview_option_id, startType, created_at, updated_at)
+                       is_open, interview_option_id, start_type, created_at, updated_at)
 VALUES (1, '백엔드 기술 면접', '서버/DB 기술 관련 인터뷰', '카카오', '백엔드 개발자', 1, 4, False, 1,
-        '2025-05-31 14:50:46', 'NOW', '2025-05-31 14:50:46'),
+        'NOW', '2025-05-31 14:50:46', '2025-05-31 14:50:46'),
        (2, '프론트엔드 기술 면접', 'React, Vue 등 프론트엔드 기술 검증', '네이버', '프론트엔드 개발자', 2, 4,
         True, 2, 'SCHEDULED', '2025-05-31 14:50:46', '2025-05-31 14:50:46'),
        (3, 'AI 실무 인터뷰', 'AI 모델 설계 및 적용 능력 검증', '토스', '데이터 엔지니어', 3, 2, False, 3, 'SCHEDULED',


### PR DESCRIPTION
## ✨ 작업 개요
✨[CCI-24] 나의 면접 리스트 조회(페이징 X)

## ✅ 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
- [📦 CHORE: git ignore 파일 수정]

- [💬 COMMENT: 면접 대기실 입장/퇴장 API, 면접 시작 API 폐기]
- 14주차 스크럼 1(2025.06.02) 결과, 면접 대기실 관련 부분은 **웹 소켓 통신**으로 전환하자는 결론이 나왔습니다.
  이에 해당 API를 폐기하고자 주석 처리했습니다.

- [🐛 FIX: **Interview에 현재 참가 인원 컬럼 추가** 및 DTO 이름 변경]
- Interview의 현재 참가 인원을 repository에서 count 쿼리로 조회하는 것이 반복되고 있어 Interview에 currentParticipants 컬럼을 추가했습니다.
- InterviewOptionDTO를 InterviewOptionDetailDTO로 더 명확한 이름으로 변경했습니다.

- [✨ FEAT: 나의 면접 리스트 조회 API]

- [📦 CHORE: intert_sql 오류 수정]
- 컬럼명은 start_type
- insert 순서 지키기

## 📌 참고 사항(선택)
- https://www.notion.so/1fccbf0e25ee80d5b95acee297bfc161?source=copy_link
- 페이징이나 정렬 기준 요청은 추후에 구현하겠습니다.

## 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

## 🔗 관련 이슈

<!--
## ✨ 작업 개요
회원가입 시 이메일 인증 기능 추가

## ✅ 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요.

- 회원가입 시 이메일 인증 요청 API 추가
- 인증 이메일 발송 기능 구현 (SMTP 기반)
- 이메일 인증 완료 시 계정 활성화 처리 로직 추가
- 관련 테스트 코드 작성 및 Postman 컬렉션 업데이트

📌 참고 사항(선택)
- Gmail SMTP를 사용하는 경우 보안 설정을 낮춰야 테스트가 가능합니다. 관련 문서는 위키에 정리해두었습니다.
- 이메일 템플릿은 기본 HTML로 구성했으며 추후 디자인 적용 예정입니다.

💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

- 이메일 인증 로직이 보안상 문제가 없는지 확인 부탁드립니다.
- 테스트 케이스가 충분한지도 검토 부탁드립니다.

🔗 관련 이슈
#42 회원가입 이메일 인증 기능
-->


[CCI-24]: https://cloudcomputinginha.atlassian.net/browse/CCI-24?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ