### PR TITLE
✅ [CCI-50] 인터뷰 현재 참가인원 동시성 테스트

### DIFF
--- a/src/test/java/cloudcomputinginha/demo/domain/InterviewTest.java
+++ b/src/test/java/cloudcomputinginha/demo/domain/InterviewTest.java
@@ -1,0 +1,79 @@
+package cloudcomputinginha.demo.domain;
+
+import cloudcomputinginha.demo.apiPayload.exception.GeneralException;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class InterviewTest {
+    private Interview interview;
+
+    @Test
+    void 쓰레드_100개가_면접을_신청하면_인터뷰의_현재참가인원은_100이다() throws InterruptedException {
+        final int REQUEST_COUNT = 100;
+        interview = Interview.builder()
+                .currentParticipants(new AtomicInteger(0))
+                .maxParticipants(REQUEST_COUNT)
+                .build();
+
+        ExecutorService execustorService = Executors.newFixedThreadPool(30);
+        CountDownLatch countDownLatch = new CountDownLatch(REQUEST_COUNT);
+
+        for (int i = 0; i < REQUEST_COUNT; i++) {
+            execustorService.submit(() -> {
+                try {
+                    interview.increaseCurrentParticipants();
+                    countDownLatch.countDown();
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            });
+        }
+
+        countDownLatch.await(); //100개의 쓰레드가 작업이 완료될 때까지 기다리기
+
+        Assertions.assertThat(interview.getCurrentParticipants().intValue()).isEqualTo(REQUEST_COUNT);
+    }
+
+    @Test
+    void 최대참가인원을_넘기면_현재참가인원은_증가하지_않는다() throws InterruptedException {
+        final int MAX_PARTICIPANTS = 15;
+        final int REQUEST_COUNT = MAX_PARTICIPANTS * 2;
+
+        interview = Interview.builder()
+                .currentParticipants(new AtomicInteger(0))
+                .maxParticipants(MAX_PARTICIPANTS)
+                .build();
+
+        ExecutorService execustorService = Executors.newFixedThreadPool(10);
+        CountDownLatch countDownLatch = new CountDownLatch(REQUEST_COUNT);
+
+        AtomicInteger success = new AtomicInteger(0);
+        AtomicInteger fail = new AtomicInteger(0);
+
+        for (int i = 0; i < REQUEST_COUNT; i++) {
+            execustorService.submit(() -> {
+                try {
+                    interview.increaseCurrentParticipants();
+                    success.incrementAndGet();
+                } catch (GeneralException e) {
+                    fail.incrementAndGet();
+                } catch (Exception e) {
+                    e.printStackTrace();
+                } finally {
+                    countDownLatch.countDown();
+                }
+            });
+        }
+
+        countDownLatch.await();
+
+        Assertions.assertThat(interview.getCurrentParticipants().intValue()).isEqualTo(MAX_PARTICIPANTS);
+        Assertions.assertThat(success.get()).isEqualTo(MAX_PARTICIPANTS);
+        Assertions.assertThat(fail.get()).isEqualTo(MAX_PARTICIPANTS);
+    }
+}


### PR DESCRIPTION
## ✨ 작업 개요
인터뷰 현재 참가인원에 대한 동시성 테스트를 진행했습니다.

일단 한 대의 서버만 가동 예정으로, Atomic 변수로 동시성을 관리하고,

여러 대의 서버로 동작한다면 비관적 락 등을 사용하여 동시성 문제를 해결할 예정입니다.

## ✅ 작업 내용
- 100개 또는 30개의 쓰레드 상황에서 
  1. 현재 참가인원을 제대로 증가시키는지, 
  2. 면접의 최대 참가인원을 넘을 경우, GeneralException을 발생시키는지 
테스트 코드를 작성했고 성공하는 것을 확인했습니다.

## 📌 참고 사항(선택)

## 💬리뷰 요구사항(선택)

## 🔗 관련 이슈
CCI-50

<!--
## ✨ 작업 개요
회원가입 시 이메일 인증 기능 추가

## ✅ 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요.

- 회원가입 시 이메일 인증 요청 API 추가
- 인증 이메일 발송 기능 구현 (SMTP 기반)
- 이메일 인증 완료 시 계정 활성화 처리 로직 추가
- 관련 테스트 코드 작성 및 Postman 컬렉션 업데이트

📌 참고 사항(선택)
- Gmail SMTP를 사용하는 경우 보안 설정을 낮춰야 테스트가 가능합니다. 관련 문서는 위키에 정리해두었습니다.
- 이메일 템플릿은 기본 HTML로 구성했으며 추후 디자인 적용 예정입니다.

💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

- 이메일 인증 로직이 보안상 문제가 없는지 확인 부탁드립니다.
- 테스트 케이스가 충분한지도 검토 부탁드립니다.

🔗 관련 이슈
#42 회원가입 이메일 인증 기능
-->
