### PR TITLE
[CCI-46] SSE 알림 기능 (

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,6 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     //implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-    //implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
@@ -55,6 +54,9 @@ dependencies {
 
     // Polling 방식이 아닌 정확히 그 시간에 시작하기 위해 새 의존성 도입
     implementation 'org.springframework.boot:spring-boot-starter-quartz'
+
+    // SSE
+    implementation 'org.springframework.boot:spring-boot-starter-web-services'
 
     //testing
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/cloudcomputinginha/demo/apiPayload/code/handler/NotificationHandler.java
+++ b/src/main/java/cloudcomputinginha/demo/apiPayload/code/handler/NotificationHandler.java
@@ -1,0 +1,10 @@
+package cloudcomputinginha.demo.apiPayload.code.handler;
+
+import cloudcomputinginha.demo.apiPayload.code.BaseErrorCode;
+import cloudcomputinginha.demo.apiPayload.exception.GeneralException;
+
+public class NotificationHandler extends GeneralException {
+    public NotificationHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/cloudcomputinginha/demo/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/cloudcomputinginha/demo/apiPayload/code/status/ErrorStatus.java
@@ -50,7 +50,9 @@ public enum ErrorStatus implements BaseErrorCode {
     URL_INVALID(HttpStatus.BAD_REQUEST, "URL4001", "URL 형식이 올바르지 않습니다."),
 
     // 알림 관련 에러
-    SSE_SEND_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "NOTIFICATION5001", "알림 전송에 실패했습니다.");
+    SSE_SEND_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "NOTIFICATION5001", "알림 전송에 실패했습니다."),
+    NOTIFICATION_TYPE_INVALID(HttpStatus.INTERNAL_SERVER_ERROR, "NOTIFICATION5002", "알림 타입이 올바르지 않습니다.");
+
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/cloudcomputinginha/demo/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/cloudcomputinginha/demo/apiPayload/code/status/ErrorStatus.java
@@ -44,7 +44,10 @@ public enum ErrorStatus implements BaseErrorCode {
     MEMBER_INTERVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBERINTERVIEW4002", "해당하는 사용자 인터뷰를 찾을 수 없습니다."),
     MEMBER_INTERVIEW_ALREADY_EXISTS(HttpStatus.CONFLICT, "MEMBERINTERVIEW4003", "이미 해당 인터뷰에 참여 신청이 완료된 회원입니다."),
     INTERVIEW_CAPACITY_EXCEEDED(HttpStatus.BAD_REQUEST, "MEMBERINTERVIEW4004", "인터뷰 정원이 초과되어 더 이상 신청할 수 없습니다."),
-    INTERVIEW_ALREADY_STARTED(HttpStatus.BAD_REQUEST, "MEMBERINTERVIEW4005", "인터뷰가 이미 시작되어 입장할 수 없습니다.");
+    INTERVIEW_ALREADY_STARTED(HttpStatus.BAD_REQUEST, "MEMBERINTERVIEW4005", "인터뷰가 이미 시작되어 입장할 수 없습니다."),
+
+    //URL
+    URL_INVALID(HttpStatus.BAD_REQUEST, "URL4001", "URL 형식이 올바르지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/cloudcomputinginha/demo/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/cloudcomputinginha/demo/apiPayload/code/status/ErrorStatus.java
@@ -46,8 +46,11 @@ public enum ErrorStatus implements BaseErrorCode {
     INTERVIEW_CAPACITY_EXCEEDED(HttpStatus.BAD_REQUEST, "MEMBERINTERVIEW4004", "인터뷰 정원이 초과되어 더 이상 신청할 수 없습니다."),
     INTERVIEW_ALREADY_STARTED(HttpStatus.BAD_REQUEST, "MEMBERINTERVIEW4005", "인터뷰가 이미 시작되어 입장할 수 없습니다."),
 
-    //URL
-    URL_INVALID(HttpStatus.BAD_REQUEST, "URL4001", "URL 형식이 올바르지 않습니다.");
+    // URL
+    URL_INVALID(HttpStatus.BAD_REQUEST, "URL4001", "URL 형식이 올바르지 않습니다."),
+
+    // 알림 관련 에러
+    SSE_SEND_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "NOTIFICATION5001", "알림 전송에 실패했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/cloudcomputinginha/demo/converter/NotificationConverter.java
+++ b/src/main/java/cloudcomputinginha/demo/converter/NotificationConverter.java
@@ -19,7 +19,7 @@ public class NotificationConverter {
     public static NotificationResponseDTO.NotificationeDTO toNotificationDTO(Notification notification) {
         return NotificationResponseDTO.NotificationeDTO.builder()
                 .type(notification.getType())
-                .url(notification.getUrl())
+                .url(notification.getUrl().getUrl())
                 .message(notification.getMessage())
                 .createdAt(notification.getCreatedAt())
                 .build();

--- a/src/main/java/cloudcomputinginha/demo/converter/NotificationConverter.java
+++ b/src/main/java/cloudcomputinginha/demo/converter/NotificationConverter.java
@@ -1,0 +1,27 @@
+package cloudcomputinginha.demo.converter;
+
+import cloudcomputinginha.demo.domain.Member;
+import cloudcomputinginha.demo.domain.Notification;
+import cloudcomputinginha.demo.domain.embedded.RelatedUrl;
+import cloudcomputinginha.demo.domain.enums.NotificationType;
+import cloudcomputinginha.demo.web.dto.NotificationResponseDTO;
+
+public class NotificationConverter {
+    public static Notification toNotification(Member receiver, NotificationType notificationType, String message, String url) {
+        return Notification.builder()
+                .receiver(receiver)
+                .type(notificationType)
+                .url(new RelatedUrl(url))
+                .message(message)
+                .build();
+    }
+
+    public static NotificationResponseDTO.NotificationeDTO toNotificationDTO(Notification notification) {
+        return NotificationResponseDTO.NotificationeDTO.builder()
+                .type(notification.getType())
+                .url(notification.getUrl())
+                .message(notification.getMessage())
+                .createdAt(notification.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/cloudcomputinginha/demo/domain/Notification.java
+++ b/src/main/java/cloudcomputinginha/demo/domain/Notification.java
@@ -1,0 +1,35 @@
+package cloudcomputinginha.demo.domain;
+
+import cloudcomputinginha.demo.domain.common.BaseEntity;
+import cloudcomputinginha.demo.domain.embedded.RelatedUrl;
+import cloudcomputinginha.demo.domain.enums.NotificationType;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Notification extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "notification_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member receiver;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 25, nullable = false)
+    private NotificationType type;
+
+    @Embedded
+    @Column(length = 255, nullable = false)
+    private RelatedUrl url;
+
+    private String message;
+
+    //TODO: 알림 읽음 처리
+}

--- a/src/main/java/cloudcomputinginha/demo/domain/embedded/RelatedUrl.java
+++ b/src/main/java/cloudcomputinginha/demo/domain/embedded/RelatedUrl.java
@@ -17,7 +17,7 @@ public class RelatedUrl {
         if (url == null || url.isBlank()) {
             throw new NotificationHandler(ErrorStatus.URL_INVALID);
         }
-        if (!url.startsWith("http") && !url.startsWith("https")) {
+        if (!url.startsWith("/")) {
             throw new NotificationHandler(ErrorStatus.URL_INVALID);
         }
         this.url = url;

--- a/src/main/java/cloudcomputinginha/demo/domain/embedded/RelatedUrl.java
+++ b/src/main/java/cloudcomputinginha/demo/domain/embedded/RelatedUrl.java
@@ -1,0 +1,25 @@
+package cloudcomputinginha.demo.domain.embedded;
+
+import cloudcomputinginha.demo.apiPayload.code.handler.NotificationHandler;
+import cloudcomputinginha.demo.apiPayload.code.status.ErrorStatus;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RelatedUrl {
+    private String url;
+
+    public RelatedUrl(String url) {
+        if (url == null || url.isBlank()) {
+            throw new NotificationHandler(ErrorStatus.URL_INVALID);
+        }
+        if (!url.startsWith("http") && !url.startsWith("https")) {
+            throw new NotificationHandler(ErrorStatus.URL_INVALID);
+        }
+        this.url = url;
+    }
+}

--- a/src/main/java/cloudcomputinginha/demo/domain/enums/InterviewStatus.java
+++ b/src/main/java/cloudcomputinginha/demo/domain/enums/InterviewStatus.java
@@ -1,7 +1,8 @@
 package cloudcomputinginha.demo.domain.enums;
 
 public enum InterviewStatus {
-    NO_SHOW, SCHEDULED, IN_PROGRESS, DONE;
+    SCHEDULED, NO_SHOW,
+    IN_PROGRESS, DONE;
 
     public static boolean isValid(String status) {
         try {

--- a/src/main/java/cloudcomputinginha/demo/domain/enums/NotificationType.java
+++ b/src/main/java/cloudcomputinginha/demo/domain/enums/NotificationType.java
@@ -1,0 +1,9 @@
+package cloudcomputinginha.demo.domain.enums;
+
+public enum NotificationType {
+    ROOM_ENTRY, // 모의면접 방 참가 알림
+    ROOM_INVITE, // 모의면접 방 초대 알림
+    INTERVIEW_REMINDER_1D, //모의면접 1일 전 리마인드
+    INTERVIEW_REMINDER_30M, //모의면접 30분 전 리마인드
+    FEEDBACK_RECEIVED //비동기 피드백 도착 알림
+}

--- a/src/main/java/cloudcomputinginha/demo/repository/MemberInterviewRepository.java
+++ b/src/main/java/cloudcomputinginha/demo/repository/MemberInterviewRepository.java
@@ -14,6 +14,8 @@ public interface MemberInterviewRepository extends JpaRepository<MemberInterview
 
     List<MemberInterview> findByInterviewId(Long interviewId);
 
+    List<MemberInterview> findWithMemberByInterviewId(Long interviewId);
+
     boolean existsByMemberIdAndInterviewId(Long memberId, Long interviewId);
 
     Optional<MemberInterview> findByMemberIdAndInterviewId(Long memberId, Long interviewId);

--- a/src/main/java/cloudcomputinginha/demo/repository/NotificationRepository.java
+++ b/src/main/java/cloudcomputinginha/demo/repository/NotificationRepository.java
@@ -1,0 +1,7 @@
+package cloudcomputinginha.demo.repository;
+
+import cloudcomputinginha.demo.domain.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+}

--- a/src/main/java/cloudcomputinginha/demo/repository/SseEmitterRepository.java
+++ b/src/main/java/cloudcomputinginha/demo/repository/SseEmitterRepository.java
@@ -1,0 +1,21 @@
+package cloudcomputinginha.demo.repository;
+
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.Map;
+
+public interface SseEmitterRepository {
+    SseEmitter save(String emitterId, SseEmitter sseEmitter);
+
+    void saveEventCache(String eventId, Object event);
+
+    Map<String, SseEmitter> findAllEmitterStartWithMemberId(String memberId);
+
+    Map<String, Object> findAllEventCacheStartWithMemberId(String memberId);
+
+    void deleteById(String emitterId);
+
+    void deleteAllEmitterStartWithId(String memberId);
+
+    void deleteAllEventCacheStartWithId(String memberId);
+}

--- a/src/main/java/cloudcomputinginha/demo/repository/SseEmitterRepositoryImpl.java
+++ b/src/main/java/cloudcomputinginha/demo/repository/SseEmitterRepositoryImpl.java
@@ -1,0 +1,66 @@
+package cloudcomputinginha.demo.repository;
+
+import org.springframework.stereotype.Repository;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+@Repository
+public class SseEmitterRepositoryImpl implements SseEmitterRepository {
+    private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
+    private final Map<String, Object> eventCache = new ConcurrentHashMap<>();
+
+    @Override
+    public SseEmitter save(String emitterId, SseEmitter sseEmitter) {
+        emitters.put(emitterId, sseEmitter);
+        return sseEmitter;
+    }
+
+    @Override
+    public void saveEventCache(String eventId, Object event) {
+        eventCache.put(eventId, event);
+    }
+
+    @Override
+    public Map<String, SseEmitter> findAllEmitterStartWithMemberId(String memberId) {
+        return emitters.entrySet().stream()
+                .filter(entry -> entry.getKey().startsWith(memberId))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    @Override
+    public Map<String, Object> findAllEventCacheStartWithMemberId(String memberId) {
+        return eventCache.entrySet().stream()
+                .filter(entry -> entry.getKey().startsWith(memberId))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    @Override
+    public void deleteById(String emitterId) {
+        emitters.remove(emitterId);
+    }
+
+    @Override
+    public void deleteAllEmitterStartWithId(String memberId) {
+        emitters.forEach(
+                (key, emitter) -> {
+                    if (key.startsWith(memberId)) {
+                        emitters.remove(key);
+                    }
+                }
+        );
+    }
+
+    @Override
+    public void deleteAllEventCacheStartWithId(String memberId) {
+        eventCache.forEach(
+                (key, emitter) -> {
+                    if (key.startsWith(memberId)) {
+                        eventCache.remove(key);
+                    }
+                }
+        );
+    }
+}

--- a/src/main/java/cloudcomputinginha/demo/repository/SseEmitterRepositoryImpl.java
+++ b/src/main/java/cloudcomputinginha/demo/repository/SseEmitterRepositoryImpl.java
@@ -15,18 +15,20 @@ public class SseEmitterRepositoryImpl implements SseEmitterRepository {
     @Override
     public SseEmitter save(String emitterId, SseEmitter sseEmitter) {
         emitters.put(emitterId, sseEmitter);
+        System.out.println("put emitterId = " + emitterId);
         return sseEmitter;
     }
 
     @Override
     public void saveEventCache(String eventId, Object event) {
         eventCache.put(eventId, event);
+        System.out.println("put eventId = " + eventId);
     }
 
     @Override
     public Map<String, SseEmitter> findAllEmitterStartWithMemberId(String memberId) {
         return emitters.entrySet().stream()
-                .filter(entry -> entry.getKey().startsWith(memberId))
+                .filter(entry -> entry.getKey().startsWith(memberId + "_"))
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 

--- a/src/main/java/cloudcomputinginha/demo/scheduler/job/InterviewReminderJob.java
+++ b/src/main/java/cloudcomputinginha/demo/scheduler/job/InterviewReminderJob.java
@@ -1,0 +1,65 @@
+package cloudcomputinginha.demo.scheduler.job;
+
+import cloudcomputinginha.demo.apiPayload.code.handler.InterviewHandler;
+import cloudcomputinginha.demo.apiPayload.code.handler.NotificationHandler;
+import cloudcomputinginha.demo.apiPayload.code.status.ErrorStatus;
+import cloudcomputinginha.demo.domain.Interview;
+import cloudcomputinginha.demo.domain.MemberInterview;
+import cloudcomputinginha.demo.domain.enums.NotificationType;
+import cloudcomputinginha.demo.repository.InterviewRepository;
+import cloudcomputinginha.demo.repository.MemberInterviewRepository;
+import cloudcomputinginha.demo.service.notification.NotificationCommandService;
+import lombok.RequiredArgsConstructor;
+import org.quartz.JobDataMap;
+import org.quartz.JobExecutionContext;
+import org.springframework.scheduling.quartz.QuartzJobBean;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class InterviewReminderJob extends QuartzJobBean {
+    private final NotificationCommandService notificationCommandService;
+    private final InterviewRepository interviewRepository;
+    private final MemberInterviewRepository memberInterviewRepository;
+
+    @Override
+    protected void executeInternal(JobExecutionContext context) {
+        JobDataMap dataMap = context.getMergedJobDataMap();
+        Long interviewId = dataMap.getLong("interviewId");
+        String type = dataMap.getString("reminderType"); // D1 or M30
+
+        Interview interview = interviewRepository.findById(interviewId)
+                .orElseThrow(() -> new InterviewHandler(ErrorStatus.INTERVIEW_NOT_FOUND));
+
+
+        List<MemberInterview> memberInterviews = memberInterviewRepository.findWithMemberByInterviewId(interviewId);
+
+        NotificationType notificationType = switch (type) {
+            case "D1" -> NotificationType.INTERVIEW_REMINDER_1D;
+            case "M30" -> NotificationType.INTERVIEW_REMINDER_30M;
+            default -> throw new NotificationHandler(ErrorStatus.NOTIFICATION_TYPE_INVALID);
+        };
+
+        String message = switch (type) {
+            case "D1" -> "1일 후 " + interview.getName() + " 모의면접 시작 예정입니다.";
+            case "M30" -> "30분 후 " + interview.getName() + "모의면접 시작 예정입니다.";
+            default -> throw new NotificationHandler(ErrorStatus.NOTIFICATION_TYPE_INVALID);
+        };
+
+        String url = "/interviews/group/" + interview.getId();
+
+        memberInterviews.stream()
+                .map(MemberInterview::getMember)
+                .forEach(receiver ->
+                        notificationCommandService.createNotificationAndSend(
+                                receiver,
+                                notificationType,
+                                message,
+                                url
+                        )
+                );
+
+    }
+}

--- a/src/main/java/cloudcomputinginha/demo/service/interview/InterviewCommandServiceImpl.java
+++ b/src/main/java/cloudcomputinginha/demo/service/interview/InterviewCommandServiceImpl.java
@@ -50,13 +50,9 @@ public class InterviewCommandServiceImpl implements InterviewCommandService {
             throw new InterviewHandler(ErrorStatus.INTERVIEW_ALREADY_TERMINATED);
         }
 
-
         if (endInterviewRequestDTO.getEndedAt().isBefore(interview.getStartedAt())) {
             throw new InterviewHandler(INTERVIEW_END_TIME_INVALID);
         }
-
-        // 사용자 상태 업데이트는 MemberInterviewService에 위임
-        memberInterviewCommandService.finalizeStatuses(interviewId);
 
         // InterviewOption 종료 시간 갱신
         interview.updateEndedAt(endInterviewRequestDTO.getEndedAt());
@@ -76,10 +72,14 @@ public class InterviewCommandServiceImpl implements InterviewCommandService {
         Coverletter coverletter = coverletterRepository.findById(request.getCoverLetterId())
                 .orElseThrow(() -> new CoverletterHandler(ErrorStatus.COVERLETTER_NOT_FOUND));
 
+        memberInterviewCommandService.validateCoverletterOwnership(coverletter.getId(), memberId);
+        memberInterviewCommandService.validateResumeOwnership(resume.getId(), memberId);
+
         InterviewOption interviewOption = InterviewConverter.toInterviewOption(request);
         interviewOptionRepository.save(interviewOption);
 
         Interview interview = InterviewConverter.toInterview(request, interviewOption, member);
+        // TODO: 초대 메일 검증 코드 + 초대 알림 전송
         interviewRepository.save(interview);
 
         MemberInterview memberInterview = MemberInterviewConverter.toMemberInterview(member, interview, resume, coverletter);
@@ -124,9 +124,9 @@ public class InterviewCommandServiceImpl implements InterviewCommandService {
             interviewWithOption.updateStartedAt(LocalDateTime.now());
         }
 
-        // 이 부분을 백엔드 -> AI로 바로 통신하는 것도 괜찮을 거 같습니다!(http request로)
-        // 면접 조회는 따로 하도록 프론트에서 변경
-        // 준비 완료시 AI -> 프론트로 소켓 통신 통해 정보 받아오는게 좋아보여요!
+        /* TODO: 이 부분을 백엔드 -> AI로 바로 통신하는 것도 괜찮을 거 같습니다!(http request로)
+            면접 조회는 따로 하도록 프론트에서 변경
+            준비 완료시 AI -> 프론트로 소켓 통신 통해 정보 받아오는게 좋아보여요! */
         return InterviewConverter.toInterviewStartResponseDTO(interviewWithOption, memberInterviews, allQnas);
     }
 

--- a/src/main/java/cloudcomputinginha/demo/service/interview/InterviewCommandServiceImpl.java
+++ b/src/main/java/cloudcomputinginha/demo/service/interview/InterviewCommandServiceImpl.java
@@ -91,6 +91,12 @@ public class InterviewCommandServiceImpl implements InterviewCommandService {
                 interview.getStartedAt()
         );
 
+        // 인터뷰 리마인드 스케줄링
+        interviewScheduler.scheduleInterviewReminderIfNotExists(
+                interview.getId(),
+                interview.getStartedAt()
+        );
+
         return InterviewConverter.createInterview(interview);
     }
 

--- a/src/main/java/cloudcomputinginha/demo/service/memberInterview/MemberInterviewCommandService.java
+++ b/src/main/java/cloudcomputinginha/demo/service/memberInterview/MemberInterviewCommandService.java
@@ -1,6 +1,8 @@
 package cloudcomputinginha.demo.service.memberInterview;
 
+import cloudcomputinginha.demo.domain.Coverletter;
 import cloudcomputinginha.demo.domain.MemberInterview;
+import cloudcomputinginha.demo.domain.Resume;
 import cloudcomputinginha.demo.domain.enums.InterviewStatus;
 import cloudcomputinginha.demo.web.dto.MemberInterviewRequestDTO;
 
@@ -13,4 +15,8 @@ public interface MemberInterviewCommandService {
     void finalizeStatuses(Long interviewId);
 
     MemberInterview changeMemberInterviewDocument(Long interviewId, MemberInterviewRequestDTO.updateDocumentDTO updateDocumentDTO);
+
+    public Coverletter validateCoverletterOwnership(Long coverletterId, Long memberId);
+
+    public Resume validateResumeOwnership(Long resumeId, Long memberId); //TODO: 해당 이력서 및 자소서 검증 로직 객체지향적으로...
 }

--- a/src/main/java/cloudcomputinginha/demo/service/memberInterview/MemberInterviewCommandServiceImpl.java
+++ b/src/main/java/cloudcomputinginha/demo/service/memberInterview/MemberInterviewCommandServiceImpl.java
@@ -7,7 +7,9 @@ import cloudcomputinginha.demo.apiPayload.code.status.ErrorStatus;
 import cloudcomputinginha.demo.converter.MemberInterviewConverter;
 import cloudcomputinginha.demo.domain.*;
 import cloudcomputinginha.demo.domain.enums.InterviewStatus;
+import cloudcomputinginha.demo.domain.enums.NotificationType;
 import cloudcomputinginha.demo.repository.*;
+import cloudcomputinginha.demo.service.notification.NotificationCommandService;
 import cloudcomputinginha.demo.web.dto.MemberInterviewRequestDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -24,6 +26,7 @@ public class MemberInterviewCommandServiceImpl implements MemberInterviewCommand
     private final InterviewRepository interviewRepository;
     private final CoverletterRepository coverletterRepository;
     private final ResumeRepository resumeRepository;
+    private final NotificationCommandService notificationCommandService;
 
     @Override
     public MemberInterview changeMemberInterviewStatus(Long interviewId, Long memberId, InterviewStatus status) {
@@ -41,11 +44,7 @@ public class MemberInterviewCommandServiceImpl implements MemberInterviewCommand
 
     @Override
     public MemberInterview createMemberInterview(Long interviewId, MemberInterviewRequestDTO.createMemberInterviewDTO createMemberInterviewDTO) {
-
         Long memberId = createMemberInterviewDTO.getMemberId();
-
-        memberInterviewRepository.findByMemberIdAndInterviewId(memberId, interviewId)
-                .orElseThrow(() -> new MemberInterviewHandler(ErrorStatus.MEMBER_INTERVIEW_NOT_FOUND));
 
         boolean alreadyExists = memberInterviewRepository.existsByMemberIdAndInterviewId(createMemberInterviewDTO.getMemberId(), interviewId);
         if (alreadyExists) {
@@ -64,6 +63,12 @@ public class MemberInterviewCommandServiceImpl implements MemberInterviewCommand
 
         MemberInterview memberInterview = MemberInterviewConverter.toMemberInterview(member, interview, resume, coverletter);
         interview.increaseCurrentParticipants(); //이 메서드 내부에서 동시성을 보호하고, 정원이 넘치면 예외를 발생시킵니다.
+
+        System.out.println("-------------------");
+        System.out.println("interview = " + interview);
+        System.out.println("member = " + member);
+        sendEntryNotificationToAllParticipants(interview, member);
+
         return memberInterviewRepository.save(memberInterview);
     }
 
@@ -116,4 +121,23 @@ public class MemberInterviewCommandServiceImpl implements MemberInterviewCommand
         return resume;
     }
 
+    private void sendEntryNotificationToAllParticipants(Interview interview, Member newMember) {
+        String interviewTitle = interview.getName();
+        String message = newMember.getName() + "님이 " + interviewTitle + " 모의면접 방에 입장하셨습니다.";
+        String redirectUrl = "/interviews/group/" + interview.getId();
+
+        List<MemberInterview> participants = memberInterviewRepository.findByInterviewId(interview.getId());
+        System.out.println(participants.size());
+        System.out.println("participants = " + participants);
+        participants.stream()
+                .map(MemberInterview::getMember)
+                .forEach(member ->
+                        notificationCommandService.createNotificationAndSend(
+                                member,
+                                NotificationType.ROOM_ENTRY,
+                                message,
+                                redirectUrl
+                        )
+                );
+    }
 }

--- a/src/main/java/cloudcomputinginha/demo/service/memberInterview/MemberInterviewCommandServiceImpl.java
+++ b/src/main/java/cloudcomputinginha/demo/service/memberInterview/MemberInterviewCommandServiceImpl.java
@@ -105,7 +105,7 @@ public class MemberInterviewCommandServiceImpl implements MemberInterviewCommand
         return memberInterview;
     }
 
-    private Coverletter validateCoverletterOwnership(Long coverletterId, Long memberId) {
+    public Coverletter validateCoverletterOwnership(Long coverletterId, Long memberId) {
         Coverletter coverletter = coverletterRepository.getReferenceById(coverletterId);
         if (!coverletter.getMember().getId().equals(memberId)) {
             throw new DocumentHandler(ErrorStatus.COVERLETTER_NOT_OWNED);
@@ -113,7 +113,7 @@ public class MemberInterviewCommandServiceImpl implements MemberInterviewCommand
         return coverletter;
     }
 
-    private Resume validateResumeOwnership(Long resumeId, Long memberId) {
+    public Resume validateResumeOwnership(Long resumeId, Long memberId) {
         Resume resume = resumeRepository.getReferenceById(memberId);
         if (!resume.getMember().getId().equals(memberId)) {
             throw new DocumentHandler(ErrorStatus.RESUME_NOT_OWNED);

--- a/src/main/java/cloudcomputinginha/demo/service/notification/NotificationCommandService.java
+++ b/src/main/java/cloudcomputinginha/demo/service/notification/NotificationCommandService.java
@@ -1,0 +1,11 @@
+package cloudcomputinginha.demo.service.notification;
+
+import cloudcomputinginha.demo.domain.Member;
+import cloudcomputinginha.demo.domain.Notification;
+import cloudcomputinginha.demo.domain.enums.NotificationType;
+
+public interface NotificationCommandService {
+    public void createNotificationAndSend(Member receiver, NotificationType notificationType, String content, String url);
+
+    public void send(Member receiver, Notification notification);
+}

--- a/src/main/java/cloudcomputinginha/demo/service/notification/NotificationCommandServiceImpl.java
+++ b/src/main/java/cloudcomputinginha/demo/service/notification/NotificationCommandServiceImpl.java
@@ -29,9 +29,9 @@ public class NotificationCommandServiceImpl implements NotificationCommandServic
         Notification notification = NotificationConverter.toNotification(receiver, notificationType, content, url);
         notificationRepository.save(notification);
 
-        String eventId = notificationSseService.createId(receiver.getId());
         String receiverId = String.valueOf(receiver.getId());
-        notificationSseService.sendToMyAllEmitters(eventId, receiverId, NotificationConverter.toNotificationDTO(notification));
+        String eventId = notificationSseService.createId(receiver.getId());
+        notificationSseService.sendToMyAllEmitters(receiverId, eventId, NotificationConverter.toNotificationDTO(notification));
     }
 
     /**
@@ -42,8 +42,8 @@ public class NotificationCommandServiceImpl implements NotificationCommandServic
      */
     @Override
     public void send(Member receiver, Notification notification) {
-        String eventId = notificationSseService.createId(receiver.getId());
         String receiverId = String.valueOf(receiver.getId());
-        notificationSseService.sendToMyAllEmitters(eventId, receiverId, NotificationConverter.toNotificationDTO(notification));
+        String eventId = notificationSseService.createId(receiver.getId());
+        notificationSseService.sendToMyAllEmitters(receiverId, eventId, NotificationConverter.toNotificationDTO(notification));
     }
 }

--- a/src/main/java/cloudcomputinginha/demo/service/notification/NotificationCommandServiceImpl.java
+++ b/src/main/java/cloudcomputinginha/demo/service/notification/NotificationCommandServiceImpl.java
@@ -1,0 +1,49 @@
+package cloudcomputinginha.demo.service.notification;
+
+import cloudcomputinginha.demo.converter.NotificationConverter;
+import cloudcomputinginha.demo.domain.Member;
+import cloudcomputinginha.demo.domain.Notification;
+import cloudcomputinginha.demo.domain.enums.NotificationType;
+import cloudcomputinginha.demo.repository.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationCommandServiceImpl implements NotificationCommandService {
+    private final NotificationRepository notificationRepository;
+    private final NotificationSseService notificationSseService;
+
+    /**
+     * Notification을 지금 생성하고 바로 알림을 주고 싶을 때 사용
+     *
+     * @param receiver
+     * @param notificationType
+     * @param content
+     * @param url
+     */
+    @Transactional
+    @Override
+    public void createNotificationAndSend(Member receiver, NotificationType notificationType, String content, String url) {
+        Notification notification = NotificationConverter.toNotification(receiver, notificationType, content, url);
+        notificationRepository.save(notification);
+
+        String eventId = notificationSseService.createId(receiver.getId());
+        String receiverId = String.valueOf(receiver.getId());
+        notificationSseService.sendToMyAllEmitters(eventId, receiverId, NotificationConverter.toNotificationDTO(notification));
+    }
+
+    /**
+     * Notification을 미리 생성해두고 나중에 또는 정해진 시간에 알림을 주고 싶을 때 사용
+     *
+     * @param receiver
+     * @param notification
+     */
+    @Override
+    public void send(Member receiver, Notification notification) {
+        String eventId = notificationSseService.createId(receiver.getId());
+        String receiverId = String.valueOf(receiver.getId());
+        notificationSseService.sendToMyAllEmitters(eventId, receiverId, NotificationConverter.toNotificationDTO(notification));
+    }
+}

--- a/src/main/java/cloudcomputinginha/demo/service/notification/NotificationSseService.java
+++ b/src/main/java/cloudcomputinginha/demo/service/notification/NotificationSseService.java
@@ -8,4 +8,6 @@ public interface NotificationSseService {
     public void sendNotification(SseEmitter emitter, String emitterId, String eventId, Object data);
 
     public String createId(Long memberId);
+
+    public void sendToMyAllEmitters(String memberId, String eventId, Object data);
 }

--- a/src/main/java/cloudcomputinginha/demo/service/notification/NotificationSseService.java
+++ b/src/main/java/cloudcomputinginha/demo/service/notification/NotificationSseService.java
@@ -1,0 +1,11 @@
+package cloudcomputinginha.demo.service.notification;
+
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+public interface NotificationSseService {
+    public SseEmitter subscribe(Long memberId, String lastEventId);
+
+    public void sendNotification(SseEmitter emitter, String emitterId, String eventId, Object data);
+
+    public String createId(Long memberId);
+}

--- a/src/main/java/cloudcomputinginha/demo/service/notification/NotificationSseServiceImpl.java
+++ b/src/main/java/cloudcomputinginha/demo/service/notification/NotificationSseServiceImpl.java
@@ -63,4 +63,15 @@ public class NotificationSseServiceImpl implements NotificationSseService {
     public String createId(Long memberId) {
         return memberId + "_" + System.currentTimeMillis();
     }
+
+    @Override
+    public void sendToMyAllEmitters(String memberId, String eventId, Object data) {
+        Map<String, SseEmitter> emitters = sseEmitterRepository.findAllEmitterStartWithMemberId(memberId);
+        emitters.forEach(
+                (emitterId, emitter) -> {
+                    sseEmitterRepository.saveEventCache(eventId, data);
+                    sendNotification(emitter, emitterId, eventId, data);
+                }
+        );
+    }
 }

--- a/src/main/java/cloudcomputinginha/demo/service/notification/NotificationSseServiceImpl.java
+++ b/src/main/java/cloudcomputinginha/demo/service/notification/NotificationSseServiceImpl.java
@@ -1,0 +1,66 @@
+package cloudcomputinginha.demo.service.notification;
+
+import cloudcomputinginha.demo.apiPayload.code.handler.NotificationHandler;
+import cloudcomputinginha.demo.apiPayload.code.status.ErrorStatus;
+import cloudcomputinginha.demo.repository.SseEmitterRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationSseServiceImpl implements NotificationSseService {
+
+    private static final Long DEFAULT_TIMEOUT = 60L * 1000 * 60; //1H
+    private final SseEmitterRepository sseEmitterRepository;
+
+    @Override
+    public SseEmitter subscribe(Long memberId, String lastEventId) {
+        // 고유한 SseEmitter 생성
+        String emitterId = createId(memberId);
+        SseEmitter emitter = new SseEmitter(DEFAULT_TIMEOUT);
+        sseEmitterRepository.save(emitterId, emitter);
+
+        // 시간 초과나 비동기 요청이 안되면 자동으로 삭제
+        emitter.onCompletion(() -> sseEmitterRepository.deleteById(emitterId));
+        emitter.onTimeout(() -> sseEmitterRepository.deleteById(emitterId));
+
+        // 503 에러 방지를 위한 더미 데이터 전송
+        String eventId = createId(memberId);
+        sendNotification(emitter, emitterId, eventId, "EventStream created. [userId=" + memberId + "]");
+
+        // 받지 못한 데이터가 존재한다면 Last-Event-ID를 기준으로 그 뒤 이벤트를 알림으로 전송
+        if (!lastEventId.isBlank()) {
+            sendLostData(lastEventId, memberId, emitterId, emitter);
+        }
+        return emitter;
+    }
+
+    private void sendLostData(String lastEventId, Long memberId, String emitterId, SseEmitter emitter) {
+        Map<String, Object> eventCaches = sseEmitterRepository.findAllEventCacheStartWithMemberId(String.valueOf(memberId));
+        eventCaches.entrySet().stream()
+                .filter(entry -> lastEventId.compareTo(entry.getKey()) < 0)
+                .forEach(entry -> sendNotification(emitter, entry.getKey(), emitterId, entry.getValue()));
+    }
+
+    @Override
+    // SseEmitter가 연결된 클라이언트에 data(string 또는 Notification)을 전송
+    public void sendNotification(SseEmitter emitter, String emitterId, String eventId, Object data) {
+        try {
+            emitter.send(SseEmitter.event()
+                    .id(eventId)
+                    .data(data));
+        } catch (IOException exception) {
+            sseEmitterRepository.deleteById(emitterId);
+            throw new NotificationHandler(ErrorStatus.SSE_SEND_FAIL);
+        }
+    }
+
+    @Override
+    public String createId(Long memberId) {
+        return memberId + "_" + System.currentTimeMillis();
+    }
+}

--- a/src/main/java/cloudcomputinginha/demo/service/notification/NotificationSseServiceImpl.java
+++ b/src/main/java/cloudcomputinginha/demo/service/notification/NotificationSseServiceImpl.java
@@ -53,6 +53,9 @@ public class NotificationSseServiceImpl implements NotificationSseService {
             emitter.send(SseEmitter.event()
                     .id(eventId)
                     .data(data));
+            System.out.println("emitter = " + emitter);
+            System.out.println("eventId = " + eventId);
+            System.out.println("data = " + data);
         } catch (IOException exception) {
             sseEmitterRepository.deleteById(emitterId);
             throw new NotificationHandler(ErrorStatus.SSE_SEND_FAIL);
@@ -66,7 +69,11 @@ public class NotificationSseServiceImpl implements NotificationSseService {
 
     @Override
     public void sendToMyAllEmitters(String memberId, String eventId, Object data) {
+        System.out.println("sendToMyAllEmitters memberId = " + memberId);
+        System.out.println("eventId = " + eventId);
+        System.out.println("data = " + data);
         Map<String, SseEmitter> emitters = sseEmitterRepository.findAllEmitterStartWithMemberId(memberId);
+        System.out.println("emitters = " + emitters.size());
         emitters.forEach(
                 (emitterId, emitter) -> {
                     sseEmitterRepository.saveEventCache(eventId, data);

--- a/src/main/java/cloudcomputinginha/demo/web/controller/NotificationController.java
+++ b/src/main/java/cloudcomputinginha/demo/web/controller/NotificationController.java
@@ -1,0 +1,27 @@
+package cloudcomputinginha.demo.web.controller;
+
+import cloudcomputinginha.demo.service.notification.NotificationSseService;
+import cloudcomputinginha.demo.validation.annotation.ExistMember;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Tag(name = "알림 API")
+@RestController
+@RequiredArgsConstructor
+public class NotificationController {
+    private final NotificationSseService notificationSseService;
+
+    @Operation(summary = "SSE 알림 구독", description = "앞으로 서버로부터 실시간 알림을 수신합니다.")
+    @GetMapping(value = "/notifications/subscribe", produces = "text/event-stream")
+    public SseEmitter subscribeNotifications(@RequestParam @ExistMember @NotNull Long memberId,
+                                             @RequestHeader(value = "Last-Event-ID", required = false, defaultValue = "") String lastEventId) {
+        return notificationSseService.subscribe(memberId, lastEventId);
+    }
+}

--- a/src/main/java/cloudcomputinginha/demo/web/dto/NotificationResponseDTO.java
+++ b/src/main/java/cloudcomputinginha/demo/web/dto/NotificationResponseDTO.java
@@ -1,0 +1,20 @@
+package cloudcomputinginha.demo.web.dto;
+
+import cloudcomputinginha.demo.domain.embedded.RelatedUrl;
+import cloudcomputinginha.demo.domain.enums.NotificationType;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+public class NotificationResponseDTO {
+    @Getter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    public static class NotificationeDTO {
+        private NotificationType type;
+        private RelatedUrl url;
+        private String message;
+        private LocalDateTime createdAt;
+    }
+}

--- a/src/main/java/cloudcomputinginha/demo/web/dto/NotificationResponseDTO.java
+++ b/src/main/java/cloudcomputinginha/demo/web/dto/NotificationResponseDTO.java
@@ -1,6 +1,5 @@
 package cloudcomputinginha.demo.web.dto;
 
-import cloudcomputinginha.demo.domain.embedded.RelatedUrl;
 import cloudcomputinginha.demo.domain.enums.NotificationType;
 import lombok.*;
 
@@ -13,7 +12,7 @@ public class NotificationResponseDTO {
     @AllArgsConstructor
     public static class NotificationeDTO {
         private NotificationType type;
-        private RelatedUrl url;
+        private String url;
         private String message;
         private LocalDateTime createdAt;
     }

--- a/src/main/resources/insert_dummy_data.sql
+++ b/src/main/resources/insert_dummy_data.sql
@@ -23,13 +23,13 @@ VALUES (1, 'GROUP', 'TECHNICAL', 'MALE30', 3, 3, '2025-05-31 14:50:46', '2025-05
        (3, 'GROUP', 'TECHNICAL', 'MALE30', 3, 4, '2025-05-31 14:50:46', '2025-05-31 14:50:46');
 
 INSERT INTO interview (interview_id, name, description, corporate_name, job_name, host_id, max_participants,
-                       is_open, interview_option_id, start_type, created_at, updated_at)
+                       is_open, interview_option_id, start_type, created_at, updated_at, current_participants)
 VALUES (1, '백엔드 기술 면접', '서버/DB 기술 관련 인터뷰', '카카오', '백엔드 개발자', 1, 4, False, 1,
-        'NOW', '2025-05-31 14:50:46', '2025-05-31 14:50:46'),
+        'NOW', '2025-05-31 14:50:46', '2025-05-31 14:50:46', 1),
        (2, '프론트엔드 기술 면접', 'React, Vue 등 프론트엔드 기술 검증', '네이버', '프론트엔드 개발자', 2, 4,
-        True, 2, 'SCHEDULED', '2025-05-31 14:50:46', '2025-05-31 14:50:46'),
+        True, 2, 'SCHEDULED', '2025-05-31 14:50:46', '2025-05-31 14:50:46', 2),
        (3, 'AI 실무 인터뷰', 'AI 모델 설계 및 적용 능력 검증', '토스', '데이터 엔지니어', 3, 2, False, 3, 'SCHEDULED',
-        '2025-05-31 14:50:46', '2025-05-31 14:50:46');
+        '2025-05-31 14:50:46', '2025-05-31 14:50:46', 2);
 
 INSERT INTO resume (resume_id, member_id, file_name, file_url, file_size, created_at, updated_at)
 VALUES (1, 1, 'resume1.pdf', '/files/resume1.pdf', 321, '2025-05-31 14:50:46', '2025-05-31 14:50:46'),


### PR DESCRIPTION
## ✨ 작업 개요
[CCI-46] SSE 알림 기능 

## ✅ 작업 내용
1. 알림 엔티티 & RelatedUrl 값 타입 생성
- Member : Notification = 1: N 관계를 가지는 Notification을 엔티티를 생성했습니다.
- 따로 Url에 대한 검증을 해당 Url에서만 진행할 수 있도록 값타입을 생성하고 `@Embedded` 로 Notification에 내장시켰습니다.

2. SSE 연결 요청 로직 개발
- SseEmitterRepository에 인메모리로 SseEmitter와 이벤트를 저장하도록 했습니다.
- 이때 인메모리로 저장한 만큼, 서버 재시작 시 연결이 소멸되지만 구현 복잡도가 낮은 인메모리로 구현하였습니다. 
  만약 다중 서버에서 실행한다면 Redis Pub/Sub로 확장할 수 있습니다.
- 또한 클라이언트 멀티탭 환경에 대비하여 사용자id + 시간대로 sseEmitter를 따로 생성하고 `sendToAllMyEmitters`로 나와 연결된 모든 emitter에서 알림을 전송하도록 개발했습니다.
- ➕ TODO: eventCache는 클라이언트 `Last-Event-ID`에 대비하여 과거에 받은 event_id에 따라 전송하지 못한 알림을 보내고자 저장했습니다. 이때 메모리 관리 측면에서 eventCache를 언제 삭제하는 것이 좋은지... 고민해 보아야 할 것 같습니다.

3. NotificationSseService로 알림을 전송하는 로직 생성
- `createNotificationAndSend`로 Notification 엔티티를 생성하고 Sse연결에 알림을 전송하는 메서드를 만들었습니다.
_- 기존 Notification을 가지고 알림만 전송하는 `send` 메서드도 존재하지만 앞으로 사용할지 모르겠습니다. 일단 아까워서 남겨뒀어용..._

4. Interview의 currentParticipants 자료형 Integer로 변경
- 과거 PR에서 동시성을 위해 AtomicInteger로 자료형을 설정했으나, Hibernate가 AtomicInteger를 직렬화하지 못하는 문제가 발생했습니다. _(따라서 Hibernate가 자동으로 DB를 생성해 줄 때 varchar(255)로 생성해 줌)_
  따라서 자료형을 Integer로 두고 `increaseParticipants`를 synchronized를 통해 동시성 문제를 해결하고자 합니다.

5. 다른 사용자가 일대다 모의면접 방에 입장했을 때 알림 전송(대기실 X)
- 사용자가 일대다 모의면접 방에 참가했을 때, 다음과 같은 알림을 전송합니다.
```json
{
    "type": "ROOM_ENTRY",
    "url": "/interviews/group/1",
    "message": "이서준님이 백엔드 기술 면접 모의면접 방에 입장하셨습니다.",
    "createdAt": "2025-06-15T13:47:52.3202284"
}
```

6. 모의면접 시작 1일 전, 30분 전 리마인드 알림 전송
- 준혁님께서 작성하신 Quartz scheduler를 재사용해서 모의면접 예정 시간 1일 전 또는 30분 전 시간에 알림을 전송하도록 했습니다.

7.  자소서, 이력서 소유자 확인 로직 추가
- ➕ TODO
1. memberInterviewService에 있는 validate 메서드를 사용하긴 했으나, 객체지향원칙에 위배되므로 추후에 리팩토링 예정입니다.
2. 면접을 생성할 때 초대 이메일을 검증하고 해당 이메일을 가진 회원에게 알림을 전송하는 로직을 개발해야 합니다.

## 📌 참고 사항(선택)
코드에 // TODO: 로 적어주시면 인텔리제이에서 앞으로 할 일을 구분하기 쉽습니당!
앞으로 할 일은 //TODO로 적어두도록 할게요!

## 💬리뷰 요구사항(선택)


## 🔗 관련 이슈
CCI-46