### PR TITLE
✨[CCI-53] 토큰 재발급 API

### DIFF
--- a/src/main/java/cloudcomputinginha/demo/config/auth/JwtProvider.java
+++ b/src/main/java/cloudcomputinginha/demo/config/auth/JwtProvider.java
@@ -1,6 +1,8 @@
 package cloudcomputinginha.demo.config.auth;
 
+import cloudcomputinginha.demo.domain.Member;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
@@ -8,6 +10,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import javax.crypto.SecretKey;
 import java.util.Date;
+import java.util.Map;
 
 @Component
 public class JwtProvider {
@@ -61,5 +64,24 @@ public class JwtProvider {
                 .getBody();
 
         return Long.parseLong(claims.getSubject());
+    }
+
+    public Map<String, String> reissueTokens(String oldRefreshToken, Member member) {
+        if (!validateToken(oldRefreshToken)) {
+            throw new JwtException("유효하지 않은 refresh token 입니다.");
+        }
+        if (!oldRefreshToken.equals(member.getRefreshToken())) {
+            throw new JwtException("저장된 refresh token과 일치하지 않습니다.");
+        }
+
+        String newAccessToken = generateAccessToken(member.getId());
+        String newRefreshToken = generateRefreshToken(member.getId());
+
+        member.setRefreshToken(newRefreshToken);
+
+        return Map.of(
+                "accessToken", newAccessToken,
+                "refreshToken", newRefreshToken
+        );
     }
 }

--- a/src/main/java/cloudcomputinginha/demo/config/auth/controller/OauthController.java
+++ b/src/main/java/cloudcomputinginha/demo/config/auth/controller/OauthController.java
@@ -1,7 +1,9 @@
 package cloudcomputinginha.demo.config.auth.controller;
 
+import cloudcomputinginha.demo.apiPayload.ApiResponse;
 import cloudcomputinginha.demo.config.auth.JwtProvider;
 import cloudcomputinginha.demo.config.auth.dto.TokenReissueRequestDto;
+import cloudcomputinginha.demo.config.auth.dto.TokenReissueResponseDto;
 import cloudcomputinginha.demo.config.auth.service.OauthService;
 import cloudcomputinginha.demo.domain.Member;
 import cloudcomputinginha.demo.domain.enums.SocialProvider;
@@ -56,7 +58,7 @@ public class OauthController {
 
     @PostMapping(value = "/reissue")
     @Operation(summary = "토큰 재발급 API", description = "refresh token을 통해 새로운 access token을 발급 받습니다.")
-    public ResponseEntity<?> reissueToken(@RequestBody TokenReissueRequestDto tokenReissueRequestDto) {
+    public ApiResponse<TokenReissueResponseDto> reissueToken(@RequestBody TokenReissueRequestDto tokenReissueRequestDto) {
         String oldRefreshToken = tokenReissueRequestDto.getRefreshToken();
 
         if (!jwtProvider.validateToken(oldRefreshToken)) {
@@ -70,6 +72,12 @@ public class OauthController {
         Map<String, String> tokens = jwtProvider.reissueTokens(oldRefreshToken, member);
         memberRepository.save(member);
 
-        return ResponseEntity.ok(tokens);
+        TokenReissueResponseDto responseDto = new TokenReissueResponseDto(
+                tokens.get("accessToken"),
+                tokens.get("refreshToken")
+        );
+
+        return ApiResponse.onSuccess(responseDto);
+
     }
 }

--- a/src/main/java/cloudcomputinginha/demo/config/auth/dto/TokenReissueRequestDto.java
+++ b/src/main/java/cloudcomputinginha/demo/config/auth/dto/TokenReissueRequestDto.java
@@ -1,0 +1,14 @@
+package cloudcomputinginha.demo.config.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TokenReissueRequestDto {
+    private String refreshToken;
+}

--- a/src/main/java/cloudcomputinginha/demo/config/auth/dto/TokenReissueResponseDto.java
+++ b/src/main/java/cloudcomputinginha/demo/config/auth/dto/TokenReissueResponseDto.java
@@ -1,0 +1,11 @@
+package cloudcomputinginha.demo.config.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TokenReissueResponseDto {
+    private String accessToken;
+    private String refreshToken;
+}


### PR DESCRIPTION
## ✨ 작업 개요


## ✅ 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
- access token이 만료되면 refresh token을 통해 재발급 받습니다.
- 이때, access token뿐만 아니라 refresh token도 새로 발급하여 전달합니다.

## 📌 참고 사항(선택)
- 

## 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

## 🔗 관련 이슈
#44 

<!--
## ✨ 작업 개요
회원가입 시 이메일 인증 기능 추가

## ✅ 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요.

- 회원가입 시 이메일 인증 요청 API 추가
- 인증 이메일 발송 기능 구현 (SMTP 기반)
- 이메일 인증 완료 시 계정 활성화 처리 로직 추가
- 관련 테스트 코드 작성 및 Postman 컬렉션 업데이트

📌 참고 사항(선택)
- Gmail SMTP를 사용하는 경우 보안 설정을 낮춰야 테스트가 가능합니다. 관련 문서는 위키에 정리해두었습니다.
- 이메일 템플릿은 기본 HTML로 구성했으며 추후 디자인 적용 예정입니다.

💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

- 이메일 인증 로직이 보안상 문제가 없는지 확인 부탁드립니다.
- 테스트 케이스가 충분한지도 검토 부탁드립니다.

🔗 관련 이슈
#42 회원가입 이메일 인증 기능
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for reissuing authentication tokens using a refresh token via a new POST endpoint.
  - Introduced a request format for submitting refresh tokens when requesting new tokens.

- **Bug Fixes**
  - Improved error handling for invalid or mismatched refresh tokens during the token reissue process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->