### PR TITLE
[ CCI-46] SSE 알림 전송 로직 수정

### DIFF
--- a/src/main/java/cloudcomputinginha/demo/config/AsyncConfig.java
+++ b/src/main/java/cloudcomputinginha/demo/config/AsyncConfig.java
@@ -1,0 +1,23 @@
+package cloudcomputinginha.demo.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@EnableAsync
+@Configuration
+public class AsyncConfig implements AsyncConfigurer {
+    @Override
+    public Executor getAsyncExecutor() {
+        ThreadPoolTaskExecutor taskExecutor = new ThreadPoolTaskExecutor();
+        taskExecutor.setCorePoolSize(1);
+        taskExecutor.setMaxPoolSize(5);
+        taskExecutor.setQueueCapacity(10);
+        taskExecutor.setThreadNamePrefix("async-thread-"); //각 스레드의 이름 설정
+        taskExecutor.initialize();
+        return taskExecutor;
+    }
+}

--- a/src/main/java/cloudcomputinginha/demo/infra/ApplicationEventPublisher.java
+++ b/src/main/java/cloudcomputinginha/demo/infra/ApplicationEventPublisher.java
@@ -1,0 +1,13 @@
+package cloudcomputinginha.demo.infra;
+
+import org.springframework.context.ApplicationEvent;
+
+@FunctionalInterface
+public interface ApplicationEventPublisher {
+
+    default void publishEvent(ApplicationEvent event) {
+        publishEvent((Object) event);
+    }
+
+    void publishEvent(Object event);
+}

--- a/src/main/java/cloudcomputinginha/demo/service/notification/NotificationSseServiceImpl.java
+++ b/src/main/java/cloudcomputinginha/demo/service/notification/NotificationSseServiceImpl.java
@@ -3,8 +3,12 @@ package cloudcomputinginha.demo.service.notification;
 import cloudcomputinginha.demo.apiPayload.code.handler.NotificationHandler;
 import cloudcomputinginha.demo.apiPayload.code.status.ErrorStatus;
 import cloudcomputinginha.demo.repository.SseEmitterRepository;
+import cloudcomputinginha.demo.service.notification.event.NotificationEvent;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.io.IOException;
@@ -16,6 +20,12 @@ public class NotificationSseServiceImpl implements NotificationSseService {
 
     private static final Long DEFAULT_TIMEOUT = 60L * 1000 * 60; //1H
     private final SseEmitterRepository sseEmitterRepository;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Async
+    public void handleCreateNotification(NotificationEvent event) {
+        sendToMyAllEmitters(event.getReceiverId(), event.getEventId(), event.getNotificationDTO());
+    }
 
     @Override
     public SseEmitter subscribe(Long memberId, String lastEventId) {

--- a/src/main/java/cloudcomputinginha/demo/service/notification/event/NotificationEvent.java
+++ b/src/main/java/cloudcomputinginha/demo/service/notification/event/NotificationEvent.java
@@ -1,0 +1,15 @@
+package cloudcomputinginha.demo.service.notification.event;
+
+import cloudcomputinginha.demo.web.dto.NotificationResponseDTO;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class NotificationEvent {
+    private final String receiverId;
+    private final String eventId;
+    private final NotificationResponseDTO.NotificationDTO notificationDTO;
+}


### PR DESCRIPTION
## ✨ 작업 개요
트랜잭션에 실패하면 알림이 전송되지 않도록 로직 수정

## ✅ 작업 내용
🐛 FIX: 알림 전송은 트랜잭션 커밋 이후 실행되는 비동기 작업으로 수정
- @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)

## 📌 참고 사항(선택)
- 

## 💬리뷰 요구사항(선택)

## 🔗 관련 이슈
CCI-46

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced asynchronous notification delivery, allowing notifications to be sent without blocking user actions.
  - Added support for event-driven notification handling, improving responsiveness and scalability.
- **Improvements**
  - Enhanced notification reliability by ensuring notifications are sent after successful transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->