### PR TITLE
✨[CCI-18] 사용자 기본 정보 등록 API

### DIFF
--- a/src/main/java/cloudcomputinginha/demo/domain/Member.java
+++ b/src/main/java/cloudcomputinginha/demo/domain/Member.java
@@ -45,4 +45,10 @@ public class Member extends BaseEntity {
     public void setRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
     }
+
+    public void updateInfo(String phone, String jobType, String introduction) {
+        this.phone = phone;
+        this.jobType = jobType;
+        this.introduction = introduction;
+    }
 }

--- a/src/main/java/cloudcomputinginha/demo/service/member/MemberCommandService.java
+++ b/src/main/java/cloudcomputinginha/demo/service/member/MemberCommandService.java
@@ -1,0 +1,8 @@
+package cloudcomputinginha.demo.service.member;
+
+import cloudcomputinginha.demo.web.dto.MemberInfoRequestDTO;
+import cloudcomputinginha.demo.web.dto.MemberInfoResponseDTO;
+
+public interface MemberCommandService {
+    MemberInfoResponseDTO updateBasicInfo(Long memberId, MemberInfoRequestDTO request);
+}

--- a/src/main/java/cloudcomputinginha/demo/service/member/MemberCommandServiceImpl.java
+++ b/src/main/java/cloudcomputinginha/demo/service/member/MemberCommandServiceImpl.java
@@ -1,0 +1,36 @@
+package cloudcomputinginha.demo.service.member;
+
+import cloudcomputinginha.demo.apiPayload.code.handler.MemberHandler;
+import cloudcomputinginha.demo.apiPayload.code.status.ErrorStatus;
+import cloudcomputinginha.demo.domain.Member;
+import cloudcomputinginha.demo.repository.MemberRepository;
+import cloudcomputinginha.demo.web.dto.MemberInfoRequestDTO;
+import cloudcomputinginha.demo.web.dto.MemberInfoResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberCommandServiceImpl implements MemberCommandService {
+    private final MemberRepository memberRepository;
+
+    @Override
+    @Transactional
+    public MemberInfoResponseDTO updateBasicInfo(Long memberId, MemberInfoRequestDTO request) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+        member.updateInfo(request.getPhone(), request.getJobType(), request.getIntroduction());
+
+
+        return MemberInfoResponseDTO.builder()
+                .memberId(memberId)
+                .name(member.getName())
+                .email(member.getEmail())
+                .phone(member.getPhone())
+                .jobType(member.getJobType())
+                .introduction(member.getIntroduction())
+                .build();
+    }
+}

--- a/src/main/java/cloudcomputinginha/demo/web/controller/MemberRestController.java
+++ b/src/main/java/cloudcomputinginha/demo/web/controller/MemberRestController.java
@@ -1,0 +1,29 @@
+package cloudcomputinginha.demo.web.controller;
+
+import cloudcomputinginha.demo.apiPayload.ApiResponse;
+import cloudcomputinginha.demo.service.member.MemberCommandService;
+import cloudcomputinginha.demo.web.dto.MemberInfoRequestDTO;
+import cloudcomputinginha.demo.web.dto.MemberInfoResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Tag(name = "사용자 API")
+@RequiredArgsConstructor
+@RequestMapping("/members")
+public class MemberRestController {
+    private final MemberCommandService memberCommandService;
+
+    @PatchMapping("/info")
+    @Operation(summary = "사용자 기본 정보 등록 API", description = "사용자의 기본 정보(전화번호, 직무 분야, 자기소개)를 등록합니다.")
+    public ApiResponse<MemberInfoResponseDTO> updateBasicInfo(@AuthenticationPrincipal Long memberId, @RequestBody MemberInfoRequestDTO request) {
+        MemberInfoResponseDTO result = memberCommandService.updateBasicInfo(memberId, request);
+        return ApiResponse.onSuccess(result);
+    }
+}

--- a/src/main/java/cloudcomputinginha/demo/web/dto/MemberInfoRequestDTO.java
+++ b/src/main/java/cloudcomputinginha/demo/web/dto/MemberInfoRequestDTO.java
@@ -1,0 +1,20 @@
+package cloudcomputinginha.demo.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberInfoRequestDTO {
+    @NotBlank
+    private String phone;
+    @NotBlank
+    private String jobType;
+    @NotBlank
+    private String introduction;
+}

--- a/src/main/java/cloudcomputinginha/demo/web/dto/MemberInfoRequestDTO.java
+++ b/src/main/java/cloudcomputinginha/demo/web/dto/MemberInfoRequestDTO.java
@@ -1,6 +1,6 @@
 package cloudcomputinginha.demo.web.dto;
 
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,10 +11,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class MemberInfoRequestDTO {
-    @NotBlank
+    @NotNull
     private String phone;
-    @NotBlank
+    @NotNull
     private String jobType;
-    @NotBlank
+    @NotNull
     private String introduction;
 }

--- a/src/main/java/cloudcomputinginha/demo/web/dto/MemberInfoResponseDTO.java
+++ b/src/main/java/cloudcomputinginha/demo/web/dto/MemberInfoResponseDTO.java
@@ -1,0 +1,19 @@
+package cloudcomputinginha.demo.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberInfoResponseDTO {
+    private Long memberId;
+    private String name;
+    private String email;
+    private String phone;
+    private String jobType;
+    private String introduction;
+}


### PR DESCRIPTION
## ✨ 작업 개요


## ✅ 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
- 사용자가 본인의 기본 정보(전화번호, 직무분야, 자기소개)를 등록합니다.

## 📌 참고 사항(선택)
- 

## 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

## 🔗 관련 이슈


<!--
## ✨ 작업 개요
회원가입 시 이메일 인증 기능 추가

## ✅ 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요.

- 회원가입 시 이메일 인증 요청 API 추가
- 인증 이메일 발송 기능 구현 (SMTP 기반)
- 이메일 인증 완료 시 계정 활성화 처리 로직 추가
- 관련 테스트 코드 작성 및 Postman 컬렉션 업데이트

📌 참고 사항(선택)
- Gmail SMTP를 사용하는 경우 보안 설정을 낮춰야 테스트가 가능합니다. 관련 문서는 위키에 정리해두었습니다.
- 이메일 템플릿은 기본 HTML로 구성했으며 추후 디자인 적용 예정입니다.

💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

- 이메일 인증 로직이 보안상 문제가 없는지 확인 부탁드립니다.
- 테스트 케이스가 충분한지도 검토 부탁드립니다.

🔗 관련 이슈
#42 회원가입 이메일 인증 기능
-->
