### PR TITLE
✨[CCI-59] 사용자 기본 정보 변경 API

### DIFF
--- a/src/main/java/cloudcomputinginha/demo/config/auth/SecurityConfig.java
+++ b/src/main/java/cloudcomputinginha/demo/config/auth/SecurityConfig.java
@@ -6,6 +6,8 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;

--- a/src/main/java/cloudcomputinginha/demo/converter/MemberConverter.java
+++ b/src/main/java/cloudcomputinginha/demo/converter/MemberConverter.java
@@ -1,0 +1,17 @@
+package cloudcomputinginha.demo.converter;
+
+import cloudcomputinginha.demo.domain.Member;
+import cloudcomputinginha.demo.web.dto.MemberInfoResponseDTO;
+
+public class MemberConverter {
+    public static MemberInfoResponseDTO toMemberInfoResponseDTO(Member member) {
+        return MemberInfoResponseDTO.builder()
+                .memberId(member.getId())
+                .name(member.getName())
+                .email(member.getEmail())
+                .phone(member.getPhone())
+                .jobType(member.getJobType())
+                .introduction(member.getIntroduction())
+                .build();
+    }
+}

--- a/src/main/java/cloudcomputinginha/demo/domain/Member.java
+++ b/src/main/java/cloudcomputinginha/demo/domain/Member.java
@@ -46,7 +46,14 @@ public class Member extends BaseEntity {
         this.refreshToken = refreshToken;
     }
 
-    public void updateInfo(String phone, String jobType, String introduction) {
+    public void registerInfo(String phone, String jobType, String introduction) {
+        this.phone = phone;
+        this.jobType = jobType;
+        this.introduction = introduction;
+    }
+
+    public void updateInfo(String name, String phone, String jobType, String introduction) {
+        this.name = name;
         this.phone = phone;
         this.jobType = jobType;
         this.introduction = introduction;

--- a/src/main/java/cloudcomputinginha/demo/service/member/MemberCommandService.java
+++ b/src/main/java/cloudcomputinginha/demo/service/member/MemberCommandService.java
@@ -4,5 +4,7 @@ import cloudcomputinginha.demo.web.dto.MemberInfoRequestDTO;
 import cloudcomputinginha.demo.web.dto.MemberInfoResponseDTO;
 
 public interface MemberCommandService {
-    MemberInfoResponseDTO updateBasicInfo(Long memberId, MemberInfoRequestDTO request);
+    MemberInfoResponseDTO registerBasicInfo(Long memberId, MemberInfoRequestDTO.registerInfoDTO request);
+
+    MemberInfoResponseDTO updateBasicInfo(Long memberId, MemberInfoRequestDTO.updateInfoDTO request);
 }

--- a/src/main/java/cloudcomputinginha/demo/service/member/MemberCommandServiceImpl.java
+++ b/src/main/java/cloudcomputinginha/demo/service/member/MemberCommandServiceImpl.java
@@ -2,6 +2,7 @@ package cloudcomputinginha.demo.service.member;
 
 import cloudcomputinginha.demo.apiPayload.code.handler.MemberHandler;
 import cloudcomputinginha.demo.apiPayload.code.status.ErrorStatus;
+import cloudcomputinginha.demo.converter.MemberConverter;
 import cloudcomputinginha.demo.domain.Member;
 import cloudcomputinginha.demo.repository.MemberRepository;
 import cloudcomputinginha.demo.web.dto.MemberInfoRequestDTO;
@@ -23,14 +24,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
 
         member.registerInfo(request.getPhone(), request.getJobType(), request.getIntroduction());
 
-        return MemberInfoResponseDTO.builder()
-                .memberId(memberId)
-                .name(member.getName())
-                .email(member.getEmail())
-                .phone(member.getPhone())
-                .jobType(member.getJobType())
-                .introduction(member.getIntroduction())
-                .build();
+        return MemberConverter.toMemberInfoResponseDTO(member);
     }
 
     @Override
@@ -41,13 +35,6 @@ public class MemberCommandServiceImpl implements MemberCommandService {
 
         member.updateInfo(request.getName(), request.getPhone(), request.getJobType(), request.getIntroduction());
 
-        return MemberInfoResponseDTO.builder()
-                .memberId(memberId)
-                .name(member.getName())
-                .email(member.getEmail())
-                .phone(member.getPhone())
-                .jobType(member.getJobType())
-                .introduction(member.getIntroduction())
-                .build();
+        return MemberConverter.toMemberInfoResponseDTO(member);
     }
 }

--- a/src/main/java/cloudcomputinginha/demo/service/member/MemberCommandServiceImpl.java
+++ b/src/main/java/cloudcomputinginha/demo/service/member/MemberCommandServiceImpl.java
@@ -17,12 +17,29 @@ public class MemberCommandServiceImpl implements MemberCommandService {
 
     @Override
     @Transactional
-    public MemberInfoResponseDTO updateBasicInfo(Long memberId, MemberInfoRequestDTO request) {
+    public MemberInfoResponseDTO registerBasicInfo(Long memberId, MemberInfoRequestDTO.registerInfoDTO request) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
 
-        member.updateInfo(request.getPhone(), request.getJobType(), request.getIntroduction());
+        member.registerInfo(request.getPhone(), request.getJobType(), request.getIntroduction());
 
+        return MemberInfoResponseDTO.builder()
+                .memberId(memberId)
+                .name(member.getName())
+                .email(member.getEmail())
+                .phone(member.getPhone())
+                .jobType(member.getJobType())
+                .introduction(member.getIntroduction())
+                .build();
+    }
+
+    @Override
+    @Transactional
+    public MemberInfoResponseDTO updateBasicInfo(Long memberId, MemberInfoRequestDTO.updateInfoDTO request) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+        member.updateInfo(request.getName(), request.getPhone(), request.getJobType(), request.getIntroduction());
 
         return MemberInfoResponseDTO.builder()
                 .memberId(memberId)

--- a/src/main/java/cloudcomputinginha/demo/web/controller/MemberRestController.java
+++ b/src/main/java/cloudcomputinginha/demo/web/controller/MemberRestController.java
@@ -6,6 +6,7 @@ import cloudcomputinginha.demo.web.dto.MemberInfoRequestDTO;
 import cloudcomputinginha.demo.web.dto.MemberInfoResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -17,16 +18,16 @@ import org.springframework.web.bind.annotation.*;
 public class MemberRestController {
     private final MemberCommandService memberCommandService;
 
-    @PatchMapping("/registerInfo")
+    @PatchMapping("")
     @Operation(summary = "사용자 기본 정보 등록 API", description = "사용자의 기본 정보(전화번호, 직무 분야, 자기소개)를 등록합니다.")
-    public ApiResponse<MemberInfoResponseDTO> registerBasicInfo(@AuthenticationPrincipal Long memberId, @RequestBody MemberInfoRequestDTO.registerInfoDTO request) {
+    public ApiResponse<MemberInfoResponseDTO> registerBasicInfo(@AuthenticationPrincipal Long memberId, @RequestBody @Valid MemberInfoRequestDTO.registerInfoDTO request) {
         MemberInfoResponseDTO result = memberCommandService.registerBasicInfo(memberId, request);
         return ApiResponse.onSuccess(result);
     }
 
-    @PatchMapping("/updateInfo")
+    @PatchMapping("/info")
     @Operation(summary = "사용자 기본 정보 변경 API", description = "사용자의 기본 정보(이름, 전화번호, 직무 분야, 자기소개)를 변경합니다.")
-    public ApiResponse<MemberInfoResponseDTO> updateBasicInfo(@AuthenticationPrincipal Long memberId, @RequestBody MemberInfoRequestDTO.updateInfoDTO request) {
+    public ApiResponse<MemberInfoResponseDTO> updateBasicInfo(@AuthenticationPrincipal Long memberId, @RequestBody @Valid MemberInfoRequestDTO.updateInfoDTO request) {
         MemberInfoResponseDTO result = memberCommandService.updateBasicInfo(memberId, request);
         return ApiResponse.onSuccess(result);
     }

--- a/src/main/java/cloudcomputinginha/demo/web/controller/MemberRestController.java
+++ b/src/main/java/cloudcomputinginha/demo/web/controller/MemberRestController.java
@@ -8,10 +8,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @Tag(name = "사용자 API")
@@ -20,9 +17,16 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemberRestController {
     private final MemberCommandService memberCommandService;
 
-    @PatchMapping("/info")
+    @PatchMapping("/registerInfo")
     @Operation(summary = "사용자 기본 정보 등록 API", description = "사용자의 기본 정보(전화번호, 직무 분야, 자기소개)를 등록합니다.")
-    public ApiResponse<MemberInfoResponseDTO> updateBasicInfo(@AuthenticationPrincipal Long memberId, @RequestBody MemberInfoRequestDTO request) {
+    public ApiResponse<MemberInfoResponseDTO> registerBasicInfo(@AuthenticationPrincipal Long memberId, @RequestBody MemberInfoRequestDTO.registerInfoDTO request) {
+        MemberInfoResponseDTO result = memberCommandService.registerBasicInfo(memberId, request);
+        return ApiResponse.onSuccess(result);
+    }
+
+    @PatchMapping("/updateInfo")
+    @Operation(summary = "사용자 기본 정보 변경 API", description = "사용자의 기본 정보(이름, 전화번호, 직무 분야, 자기소개)를 변경합니다.")
+    public ApiResponse<MemberInfoResponseDTO> updateBasicInfo(@AuthenticationPrincipal Long memberId, @RequestBody MemberInfoRequestDTO.updateInfoDTO request) {
         MemberInfoResponseDTO result = memberCommandService.updateBasicInfo(memberId, request);
         return ApiResponse.onSuccess(result);
     }

--- a/src/main/java/cloudcomputinginha/demo/web/dto/MemberInfoRequestDTO.java
+++ b/src/main/java/cloudcomputinginha/demo/web/dto/MemberInfoRequestDTO.java
@@ -1,6 +1,8 @@
 package cloudcomputinginha.demo.web.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,6 +15,11 @@ public class MemberInfoRequestDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class registerInfoDTO {
+        @Schema(description = "휴대폰 번호", example = "010-1234-5678")
+        @Pattern(
+                regexp = "^01[016789]-\\d{4}-\\d{4}$",
+                message = "올바른 휴대폰 번호 형식이 아닙니다. 예: 010-1234-5678"
+        )
         @NotNull
         private String phone;
         @NotNull
@@ -28,6 +35,11 @@ public class MemberInfoRequestDTO {
     public static class updateInfoDTO {
         @NotNull
         private String name;
+        @Schema(description = "휴대폰 번호", example = "010-1234-5678")
+        @Pattern(
+                regexp = "^01[016789]-\\d{4}-\\d{4}$",
+                message = "올바른 휴대폰 번호 형식이 아닙니다. 예: 010-1234-5678"
+        )
         @NotNull
         private String phone;
         @NotNull

--- a/src/main/java/cloudcomputinginha/demo/web/dto/MemberInfoRequestDTO.java
+++ b/src/main/java/cloudcomputinginha/demo/web/dto/MemberInfoRequestDTO.java
@@ -6,15 +6,33 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Getter
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
 public class MemberInfoRequestDTO {
-    @NotNull
-    private String phone;
-    @NotNull
-    private String jobType;
-    @NotNull
-    private String introduction;
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class registerInfoDTO {
+        @NotNull
+        private String phone;
+        @NotNull
+        private String jobType;
+        @NotNull
+        private String introduction;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class updateInfoDTO {
+        @NotNull
+        private String name;
+        @NotNull
+        private String phone;
+        @NotNull
+        private String jobType;
+        @NotNull
+        private String introduction;
+    }
 }


### PR DESCRIPTION
## ✨ 작업 개요


## ✅ 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
- 사용자는 기본 정보(이름, 전화번호, 직무 분야, 자기소개)를 변경합니다.

## 📌 참고 사항(선택)
- 

## 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

## 🔗 관련 이슈


<!--
## ✨ 작업 개요
회원가입 시 이메일 인증 기능 추가

## ✅ 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요.

- 회원가입 시 이메일 인증 요청 API 추가
- 인증 이메일 발송 기능 구현 (SMTP 기반)
- 이메일 인증 완료 시 계정 활성화 처리 로직 추가
- 관련 테스트 코드 작성 및 Postman 컬렉션 업데이트

📌 참고 사항(선택)
- Gmail SMTP를 사용하는 경우 보안 설정을 낮춰야 테스트가 가능합니다. 관련 문서는 위키에 정리해두었습니다.
- 이메일 템플릿은 기본 HTML로 구성했으며 추후 디자인 적용 예정입니다.

💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

- 이메일 인증 로직이 보안상 문제가 없는지 확인 부탁드립니다.
- 테스트 케이스가 충분한지도 검토 부탁드립니다.

🔗 관련 이슈
#42 회원가입 이메일 인증 기능
-->
