### PR TITLE
[CCI-77] 면접 시작 정보 조회 API [개발용]

### DIFF
--- a/src/main/java/cloudcomputinginha/demo/domain/MemberInterview.java
+++ b/src/main/java/cloudcomputinginha/demo/domain/MemberInterview.java
@@ -37,6 +37,10 @@ public class MemberInterview extends BaseEntity {
     @Builder.Default
     private InterviewStatus status = InterviewStatus.SCHEDULED;
 
+    public boolean hasResumeAndCoverLetter() {
+        return this.resume != null && this.coverletter != null;
+    }
+
     public void updateStatus(InterviewStatus status) {
         this.status = status;
     }

--- a/src/main/java/cloudcomputinginha/demo/service/interview/InterviewCommandServiceImpl.java
+++ b/src/main/java/cloudcomputinginha/demo/service/interview/InterviewCommandServiceImpl.java
@@ -121,8 +121,8 @@ public class InterviewCommandServiceImpl implements InterviewCommandService {
                 .orElseThrow(() -> new InterviewHandler(ErrorStatus.MEMBER_INTERVIEW_NOT_FOUND));
 
         // 2-2. 참가자가 자소서, 이력서가 모두 존재하는지 확인(둘 다 필수여야 함)
-        if (memberInterview.getResume() == null || memberInterview.getCoverletter() == null) {
-            throw new InterviewHandler(ErrorStatus.INTERVIEW_DOCUMENTS_NOT_FOUND);
+        if (!memberInterview.hasResumeAndCoverLetter()) {
+            throw new MemberInterviewHandler(ErrorStatus.INTERVIEW_DOCUMENTS_NOT_FOUND);
         }
 
         // 2-3. 참가자의 memberInterview 상태 변경
@@ -153,7 +153,7 @@ public class InterviewCommandServiceImpl implements InterviewCommandService {
 
         // 2-3. 참가자들의 자소서, 이력서가 모두 존재하는지 확인(둘 다 필수여야 함)
         if (inProgressMemberInterviews.stream()
-                .anyMatch(mi -> mi.getResume() == null || mi.getCoverletter() == null)) {
+                .anyMatch(mi -> !mi.hasResumeAndCoverLetter())) {
             throw new InterviewHandler(ErrorStatus.INTERVIEW_DOCUMENTS_NOT_FOUND);
         }
 

--- a/src/main/java/cloudcomputinginha/demo/service/interview/InterviewQueryService.java
+++ b/src/main/java/cloudcomputinginha/demo/service/interview/InterviewQueryService.java
@@ -15,10 +15,19 @@ public interface InterviewQueryService {
     /**
      * 현재 시간으로부터 예정된 모든 Interview를 조회한다.
      *
-     * @param currentTime
+     * @param currentTime 현재 시간
      * @return List<Interview>
      */
     List<Interview> getUpcomingInterviews(LocalDateTime currentTime);
 
     Optional<Interview> getInterview(Long interviewId);
+
+    /**
+     * 면접 시작 정보를 조회하는 메서드
+     *
+     * @param memberId 조회하는 사용자 id
+     * @param interviewId 조회할 면접 id
+     * @return InterviewResponseDTO.InterviewStartResponseDTO
+     */
+    InterviewResponseDTO.InterviewStartResponseDTO getStartInterviewInfo(Long memberId, Long interviewId);
 }

--- a/src/main/java/cloudcomputinginha/demo/service/interview/InterviewQueryServiceImpl.java
+++ b/src/main/java/cloudcomputinginha/demo/service/interview/InterviewQueryServiceImpl.java
@@ -67,4 +67,28 @@ public class InterviewQueryServiceImpl implements InterviewQueryService {
     public Optional<Interview> getInterview(Long interviewId) {
         return interviewRepository.findById(interviewId);
     }
+
+    @Override
+    @Transactional(readOnly = true)
+    public InterviewResponseDTO.InterviewStartResponseDTO getStartInterviewInfo(Long memberId, Long interviewId) {
+        // 1. 면접과 면접 옵션 조회
+        Interview interviewWithOption = interviewRepository.findWithInterviewOptionById(interviewId)
+                .orElseThrow(() -> new InterviewHandler(ErrorStatus.INTERVIEW_NOT_FOUND));
+
+        // 2. 면접 참여자 조회
+        List<MemberInterview> memberInterviews = memberInterviewRepository.findByInterviewId(interviewId);
+
+        // 3. 현재 사용자가 면접 참여자인지 확인
+        if (memberInterviews.stream()
+                .noneMatch(mi -> mi.getMember().getId().equals(memberId))) {
+            throw new InterviewHandler(ErrorStatus.INTERVIEW_NO_PERMISSION);
+        }
+
+        // 4. 참가자들의 자소서, 이력서 존재하는지 확인
+        if (memberInterviews.stream()
+                .anyMatch(mi -> mi.getResume() == null || mi.getCoverletter() == null)) {
+            throw new InterviewHandler(ErrorStatus.INTERVIEW_DOCUMENTS_NOT_FOUND);
+        }
+        return InterviewConverter.toInterviewStartResponseDTO(interviewWithOption, memberInterviews);
+    }
 }

--- a/src/main/java/cloudcomputinginha/demo/service/interview/InterviewQueryServiceImpl.java
+++ b/src/main/java/cloudcomputinginha/demo/service/interview/InterviewQueryServiceImpl.java
@@ -86,7 +86,7 @@ public class InterviewQueryServiceImpl implements InterviewQueryService {
 
         // 4. 참가자들의 자소서, 이력서 존재하는지 확인
         if (memberInterviews.stream()
-                .anyMatch(mi -> mi.getResume() == null || mi.getCoverletter() == null)) {
+                .anyMatch(mi -> !mi.hasResumeAndCoverLetter())) {
             throw new InterviewHandler(ErrorStatus.INTERVIEW_DOCUMENTS_NOT_FOUND);
         }
         return InterviewConverter.toInterviewStartResponseDTO(interviewWithOption, memberInterviews);

--- a/src/main/java/cloudcomputinginha/demo/service/memberInterview/MemberInterviewSocketServiceImpl.java
+++ b/src/main/java/cloudcomputinginha/demo/service/memberInterview/MemberInterviewSocketServiceImpl.java
@@ -35,7 +35,7 @@ public class MemberInterviewSocketServiceImpl implements MemberInterviewSocketSe
         if (hasInterviewEnded(memberInterview)) {
             throw new MemberInterviewHandler(ErrorStatus.INTERVIEW_ALREADY_STARTED);
         }
-        if (memberInterview.getResume() == null || memberInterview.getCoverletter() == null) {
+        if (!memberInterview.hasResumeAndCoverLetter()) {
             throw new MemberInterviewHandler(ErrorStatus.INTERVIEW_DOCUMENTS_NOT_FOUND);
         }
 

--- a/src/main/java/cloudcomputinginha/demo/web/controller/InterviewRestController.java
+++ b/src/main/java/cloudcomputinginha/demo/web/controller/InterviewRestController.java
@@ -61,7 +61,7 @@ public class InterviewRestController {
     }
 
     @GetMapping("/{interviewId}")
-    @Operation(summary = "면접 시작 정보 조회 API", description = "[개발용] 해당 API가 호출되면 AI서버에게 넘겨줄 면접의 모든 정보를 넘겨줍니다.")
+    @Operation(summary = "면접 시작 정보 조회 API", description = "[개발용] 이 API는 데이터베이스 상태를 변경하지 않는 읽기 전용(READ-ONLY) 작업입니다. 실제 면접 시작 API와 달리, 면접의 모든 정보를 AI서버에 넘겨주지만 면접 시작 시간이나 사용자 면접 상태를 변경하지 않습니다.")
     public ApiResponse<InterviewResponseDTO.InterviewStartResponseDTO> getStartInterviewInfo(@AuthenticationPrincipal Long memberId, @PathVariable @ExistInterview Long interviewId) {
         InterviewResponseDTO.InterviewStartResponseDTO interviewStartResponse = interviewQueryService.getStartInterviewInfo(memberId, interviewId);
         return ApiResponse.onSuccess(interviewStartResponse);

--- a/src/main/java/cloudcomputinginha/demo/web/controller/InterviewRestController.java
+++ b/src/main/java/cloudcomputinginha/demo/web/controller/InterviewRestController.java
@@ -15,7 +15,6 @@ import cloudcomputinginha.demo.web.dto.InterviewResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
@@ -55,9 +54,16 @@ public class InterviewRestController {
     }
 
     @GetMapping("/{interviewId}/start")
-    @Operation(summary = "면접 시작 API", description = "해당 API가 호출되면 AI서버에게 넘겨줄 면접의 모든 정보를 넘겨줍니다.")
-    public ApiResponse<InterviewResponseDTO.InterviewStartResponseDTO> startInterview(@AuthenticationPrincipal Long memberId, @PathVariable @NotNull Long interviewId) {
+    @Operation(summary = "면접 시작 API", description = "해당 API가 호출되면 AI서버에게 넘겨줄 면접의 모든 정보를 넘겨주고, 면접 시작 시간과 사용자 면접 상태를 변경합니다.")
+    public ApiResponse<InterviewResponseDTO.InterviewStartResponseDTO> startInterview(@AuthenticationPrincipal Long memberId, @PathVariable Long interviewId) {
         InterviewResponseDTO.InterviewStartResponseDTO interviewStartResponse = interviewCommandService.startInterview(memberId, interviewId, false);
+        return ApiResponse.onSuccess(interviewStartResponse);
+    }
+
+    @GetMapping("/{interviewId}")
+    @Operation(summary = "면접 시작 정보 조회 API", description = "[개발용] 해당 API가 호출되면 AI서버에게 넘겨줄 면접의 모든 정보를 넘겨줍니다.")
+    public ApiResponse<InterviewResponseDTO.InterviewStartResponseDTO> getStartInterviewInfo(@AuthenticationPrincipal Long memberId, @PathVariable @ExistInterview Long interviewId) {
+        InterviewResponseDTO.InterviewStartResponseDTO interviewStartResponse = interviewQueryService.getStartInterviewInfo(memberId, interviewId);
         return ApiResponse.onSuccess(interviewStartResponse);
     }
 

--- a/src/main/java/cloudcomputinginha/demo/web/controller/InterviewRestController.java
+++ b/src/main/java/cloudcomputinginha/demo/web/controller/InterviewRestController.java
@@ -34,7 +34,7 @@ public class InterviewRestController {
 
     @PatchMapping("/{interviewId}/end")
     @Operation(summary = "면접 종료 API", description = "면접 종료 시간과 사용자 면접의 상태를 변경합니다.")
-    public ApiResponse<InterviewResponseDTO.InterviewEndResultDTO> terminateInterview(@AuthenticationPrincipal Long memberId, @PathVariable @ExistInterview @NotNull Long interviewId, @RequestBody @Valid InterviewRequestDTO.endInterviewRequestDTO endInterviewRequestDTO) {
+    public ApiResponse<InterviewResponseDTO.InterviewEndResultDTO> terminateInterview(@AuthenticationPrincipal Long memberId, @PathVariable @ExistInterview Long interviewId, @RequestBody @Valid InterviewRequestDTO.endInterviewRequestDTO endInterviewRequestDTO) {
         Interview interview = interviewCommandService.terminateInterview(memberId, interviewId, endInterviewRequestDTO);
         return ApiResponse.onSuccess(InterviewConverter.toInterviewEndResultDTO(interview));
     }
@@ -69,7 +69,7 @@ public class InterviewRestController {
 
     @GetMapping("/group/{interviewId}")
     @Operation(summary = "일대다 면접 모집글 세부 조회 API", description = "일대다 면접 모집글 세부를 조회합니다.")
-    public ApiResponse<InterviewResponseDTO.GroupInterviewDetailDTO> getGroupInterviewDetail(@AuthenticationPrincipal Long memberId, @PathVariable @NotNull @ExistInterview Long interviewId) {
+    public ApiResponse<InterviewResponseDTO.GroupInterviewDetailDTO> getGroupInterviewDetail(@AuthenticationPrincipal Long memberId, @PathVariable @ExistInterview Long interviewId) {
         return ApiResponse.onSuccess(interviewQueryService.getGroupInterviewDetail(memberId, interviewId));
     }
 

--- a/src/main/java/cloudcomputinginha/demo/web/controller/MemberInterviewRestController.java
+++ b/src/main/java/cloudcomputinginha/demo/web/controller/MemberInterviewRestController.java
@@ -11,7 +11,6 @@ import cloudcomputinginha.demo.web.dto.MemberInterviewResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
@@ -32,7 +31,7 @@ public class MemberInterviewRestController {
     @Operation(summary = "면접 대기실 내 사용자의 상태를 변경하는 API", description = "면접, 사용자 id, 사용자 상태를 요청 받아 사용자 면접의 상태를 수정합니다.")
     public ApiResponse<MemberInterviewResponseDTO.MemberInterviewStatusDTO> changeParticipantsStatus(
             @AuthenticationPrincipal Long memberId,
-            @PathVariable @ExistInterview @NotNull Long interviewId,
+            @PathVariable @ExistInterview Long interviewId,
             @RequestBody @Valid MemberInterviewRequestDTO.changeMemberStatusDTO changeMemberStatusDTO) {
         MemberInterview memberInterview = memberInterviewCommandService.changeMemberInterviewStatus(interviewId, memberId, changeMemberStatusDTO.getStatus());
         return ApiResponse.onSuccess(MemberInterviewConverter.toMemberInterviewStatusDTO(memberInterview));
@@ -42,7 +41,7 @@ public class MemberInterviewRestController {
     @Operation(summary = "일대다 면접 참여 신청 API", description = "면접, 사용자, 이력서, 자소서 id를 전부 받아와 사용자 면접을 생성합니다.")
     public ApiResponse<MemberInterviewResponseDTO.CreateMemberInterviewDTO> createMemberInterview(
             @AuthenticationPrincipal Long memberId,
-            @PathVariable @ExistInterview @NotNull Long interviewId,
+            @PathVariable @ExistInterview Long interviewId,
             @RequestBody @Valid MemberInterviewRequestDTO.createMemberInterviewDTO createMemberInterviewDTO) {
         MemberInterview memberInterview = memberInterviewCommandService.createMemberInterview(interviewId, memberId, createMemberInterviewDTO);
         return ApiResponse.onSuccess(MemberInterviewConverter.toMemberInterviewResultDTO(memberInterview));
@@ -59,7 +58,7 @@ public class MemberInterviewRestController {
     @Operation(summary = "나의 면접에서 자기소개서 또는 이력서 변경 API", description = "면접 시작전, 자기소개서나 이력서를 변경(변경할 ID) 합니다. 만약 변경하지 않을 경우 기존 아이디를 담아서 요청해주세요!")
     public ApiResponse<MemberInterviewResponseDTO.MemberInterviewDocumentDTO> updateInterviewDocuments(
             @AuthenticationPrincipal Long memberId,
-            @PathVariable @NotNull @ExistInterview Long interviewId,
+            @PathVariable @ExistInterview Long interviewId,
             @RequestBody @Valid MemberInterviewRequestDTO.updateDocumentDTO updateDocumentDTO) {
         MemberInterview memberInterview = memberInterviewCommandService.changeMemberInterviewDocument(interviewId, memberId, updateDocumentDTO);
         return ApiResponse.onSuccess(MemberInterviewConverter.toMemberInterviewDocumentDTO(memberInterview));


### PR DESCRIPTION
## ✨ 작업 개요
[CCI-77] 면접 시작 정보 조회 API

## ✅ 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
- **DB 상태를 변경하지 않고, 면접과 연관된 모든 참석자(Inprogress 참석자 X)에 대한 정보를 제공**하는 API

## 📌 참고 사항(선택)
- 

## 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

## 🔗 관련 이슈
CCI-77


[CCI-77]: https://cloudcomputinginha.atlassian.net/browse/CCI-77?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new API endpoint to retrieve interview start information for a specific interview and user.

* **Bug Fixes**
  * Improved validation handling by removing unnecessary parameter annotations from several interview-related endpoints.

* **Documentation**
  * Updated endpoint descriptions for clarity regarding interview start and status changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->